### PR TITLE
fix: address security vulnerabilities in unsafe memory access and XML parsing

### DIFF
--- a/src/SbeCodeGenerator/AnalyzerReleases.Unshipped.md
+++ b/src/SbeCodeGenerator/AnalyzerReleases.Unshipped.md
@@ -1,1 +1,5 @@
 ### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+SBE007 | SbeSourceGenerator | Warning | Non-native byte order.

--- a/src/SbeCodeGenerator/Diagnostics/SbeDiagnostics.cs
+++ b/src/SbeCodeGenerator/Diagnostics/SbeDiagnostics.cs
@@ -68,5 +68,15 @@ namespace SbeSourceGenerator.Diagnostics
             defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true,
             description: "A type definition has an invalid length attribute value.");
+
+        // SBE007: Non-native byte order
+        public static readonly DiagnosticDescriptor NonNativeByteOrder = new DiagnosticDescriptor(
+            id: "SBE007",
+            title: "Non-native byte order",
+            messageFormat: "Schema '{0}' specifies byteOrder='{1}' but the generator only supports native (little-endian) byte order. Generated code will not apply endianness conversion and may produce incorrect values on this platform.",
+            category: Category,
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: "The schema specifies a byte order that differs from the platform's native endianness. The generator does not emit byte-swap logic, so multi-byte fields will be read/written incorrectly.");
     }
 }

--- a/src/SbeCodeGenerator/FileContentGeneratorExtensions.cs
+++ b/src/SbeCodeGenerator/FileContentGeneratorExtensions.cs
@@ -6,20 +6,23 @@ namespace SbeSourceGenerator
     {
         public static int SumFieldLength(this IEnumerable<IFileContentGenerator> fields)
         {
-            int offset = 0;
-            foreach (var field in fields)
+            checked
             {
-                if (field is IBlittableMessageField blittableMessageField)
+                int offset = 0;
+                foreach (var field in fields)
                 {
-                    blittableMessageField.Offset ??= offset;
-                    offset = blittableMessageField.Offset.Value + blittableMessageField.Length;
+                    if (field is IBlittableMessageField blittableMessageField)
+                    {
+                        blittableMessageField.Offset ??= offset;
+                        offset = blittableMessageField.Offset.Value + blittableMessageField.Length;
+                    }
+                    else if (field is IBlittable blittable)
+                    {
+                        offset += blittable.Length;
+                    }
                 }
-                else if (field is IBlittable blittable)
-                {
-                    offset += blittable.Length;
-                }
+                return offset;
             }
-            return offset;
         }
     }
 }

--- a/src/SbeCodeGenerator/Generators/Types/MessageDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Types/MessageDefinition.cs
@@ -66,6 +66,11 @@ namespace SbeSourceGenerator
             sb.AppendLine("else", tabs);
             sb.AppendLine("{", tabs++);
             sb.AppendLine("// For backward compatibility: variable data starts at blockLength", tabs);
+            sb.AppendLine("if (blockLength > buffer.Length)", tabs);
+            sb.AppendLine("{", tabs++);
+            sb.AppendLine("variableData = default;", tabs);
+            sb.AppendLine("return false;", tabs);
+            sb.AppendLine("}", --tabs);
             sb.AppendLine("variableData = buffer.Slice(blockLength);", tabs);
             sb.AppendLine("}", --tabs);
             sb.AppendLine("", tabs);
@@ -259,10 +264,11 @@ namespace SbeSourceGenerator
                     sb.AppendLine("{", tabs++);
                     sb.AppendLine($"for (int i = 0; i < group{group.Name}.NumInGroup; i++)", tabs);
                     sb.AppendLine("{", tabs++);
-                    sb.AppendLine($"if (reader.TryRead<{group.Name}Data>(out var data))", tabs);
+                    sb.AppendLine($"if (!reader.TryRead<{group.Name}Data>(out var data))", tabs);
                     sb.AppendLine("{", tabs++);
-                    sb.AppendLine($"callback{group.Name}(data);", tabs);
+                    sb.AppendLine("break;", tabs);
                     sb.AppendLine("}", --tabs);
+                    sb.AppendLine($"callback{group.Name}(data);", tabs);
                     sb.AppendLine("}", --tabs);
                     sb.AppendLine("}", --tabs);
                 }

--- a/src/SbeCodeGenerator/SBESourceGenerator.cs
+++ b/src/SbeCodeGenerator/SBESourceGenerator.cs
@@ -52,8 +52,16 @@ namespace SbeSourceGenerator
                     try
                     {
                         string path = additionalText.Path;
-                        var d = new XmlDocument();
-                        d.Load(path);
+                        var d = new XmlDocument { XmlResolver = null };
+                        var readerSettings = new XmlReaderSettings
+                        {
+                            DtdProcessing = DtdProcessing.Prohibit,
+                            XmlResolver = null
+                        };
+                        using (var xmlReader = XmlReader.Create(path, readerSettings))
+                        {
+                            d.Load(xmlReader);
+                        }
 
                         string ns = GetNamespaceFromSchema(d, path);
                         string schemaKey = CreateSchemaKey(path);
@@ -69,6 +77,15 @@ namespace SbeSourceGenerator
                             if (!string.IsNullOrEmpty(byteOrderAttr))
                             {
                                 context.ByteOrder = byteOrderAttr;
+                                if (!byteOrderAttr.Equals("littleEndian", StringComparison.OrdinalIgnoreCase)
+                                    && !sourceContext.CancellationToken.IsCancellationRequested)
+                                {
+                                    sourceContext.ReportDiagnostic(Diagnostic.Create(
+                                        SbeDiagnostics.NonNativeByteOrder,
+                                        Location.None,
+                                        path,
+                                        byteOrderAttr));
+                                }
                             }
                         }
 

--- a/tests/SbeCodeGenerator.Tests/Snapshots/MessagesCodeGenerator.Message.Quote.verified.txt
+++ b/tests/SbeCodeGenerator.Tests/Snapshots/MessagesCodeGenerator.Message.Quote.verified.txt
@@ -71,6 +71,11 @@ public partial struct QuoteData
 		else
 		{
 			// For backward compatibility: variable data starts at blockLength
+			if (blockLength > buffer.Length)
+			{
+				variableData = default;
+				return false;
+			}
 			variableData = buffer.Slice(blockLength);
 		}
 		

--- a/tests/SbeCodeGenerator.Tests/Snapshots/MessagesCodeGenerator.Message.Trade.verified.txt
+++ b/tests/SbeCodeGenerator.Tests/Snapshots/MessagesCodeGenerator.Message.Trade.verified.txt
@@ -71,6 +71,11 @@ public partial struct TradeData
 		else
 		{
 			// For backward compatibility: variable data starts at blockLength
+			if (blockLength > buffer.Length)
+			{
+				variableData = default;
+				return false;
+			}
 			variableData = buffer.Slice(blockLength);
 		}
 		


### PR DESCRIPTION
## Summary

Security audit identified 6 vulnerabilities related to `unsafe` memory access, XML parsing, and data validation. This PR addresses all actionable items.

## Changes

### 🔴 Critical — XXE Vulnerability (`SBESourceGenerator.cs`)
- `XmlDocument` was loaded with default settings, allowing DTD processing and external entity resolution
- **Fix:** Use `XmlReaderSettings` with `DtdProcessing.Prohibit` and `XmlResolver = null`

### 🔴 Critical — Group Loop Runaway (`MessageDefinition.cs`)
- `ConsumeVariableLengthSegments` looped `NumInGroup` times from untrusted binary data without breaking on failed reads
- A malicious message with large `NumInGroup` would cause CPU waste and silent data loss
- **Fix:** `break` immediately on failed `TryRead` instead of silently continuing

### 🟠 High — Unbounded `buffer.Slice(blockLength)` (`MessageDefinition.cs`)
- `TryParse` backward compat path called `buffer.Slice(blockLength)` without validating `blockLength <= buffer.Length`
- **Fix:** Guard with bounds check, return `false` if invalid

### 🟡 Medium — Integer Overflow in Offset Calculations (`FileContentGeneratorExtensions.cs`)
- `SumFieldLength()` used unchecked integer addition — malicious schema field lengths could overflow, producing incorrect `[FieldOffset]` values
- **Fix:** Wrap in `checked{}` block to throw `OverflowException` on overflow

### 🟡 Medium — Non-native Endianness (`SbeDiagnostics.cs`, `SBESourceGenerator.cs`)
- `ByteOrder` was stored but never used in code generation — big-endian schemas produce silently wrong values
- **Fix:** New `SBE007` warning diagnostic when schema specifies non-native byte order

### ✅ Already Handled — VarData Length Truncation
- The `data.Length > 255` check already existed at `MessageDefinition.cs:197`. No action needed.

## Testing
- All **107 unit tests** pass ✅
- **2 pre-existing** integration test failures (unrelated `VersioningIntegrationTests`)
- Snapshot files updated to reflect new bounds check in generated `TryParse`
