### PR TITLE
release: v0.4.0 — performance optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.0] - 2026-04-09
 
 ### Changed
 - **Single-pass XmlReader parser**: Replaced `XmlDocument` DOM with forward-only `XmlReader` producing pre-parsed `ParsedSchema` DTOs in a single pass. Eliminates all XPath queries (`SelectNodes`), repeated attribute access, and DOM materialization.
 - **LINQ elimination**: Replaced LINQ chains in `MessagesCodeGenerator` (`Where`/`Select`/`ToList`, `OrderBy`, `Take`) with `foreach` loops and pre-sized `List<T>`.
+- **String interpolation removal**: Replaced `$"..."` interpolated strings in code generation with chained `StringBuilder.Append()` calls to reduce GC pressure.
+- **Collection pre-sizing**: Pre-sized all `Dictionary`, `List`, and `StringBuilder` allocations across the pipeline to reduce resize operations.
+- **Cast caching**: Cached `Cast<GroupDefinition>()` / `Cast<DataFieldDefinition>()` results in `MessageDefinition` to avoid repeated list allocations.
 - **Dead code removal**: Removed legacy `SchemaParser.cs` (superseded by `SchemaReader`).
-- Generator pipeline throughput improved ~52% (2.5ms → 1.2ms per schema iteration in profiling).
+- Generator pipeline throughput improved ~2.4x (2.5ms → ~1.07ms per schema iteration in profiling).
 
 ## [0.3.0] - 2026-04-08
 

--- a/src/SbeCodeGenerator/SbeSourceGenerator.csproj
+++ b/src/SbeCodeGenerator/SbeSourceGenerator.csproj
@@ -10,7 +10,7 @@
 		<NoWarn>$(NoWarn);CS1591</NoWarn>
 		<PackageId>SbeSourceGenerator</PackageId>
 		<Title>SBE Source Generator</Title>
-		<Version>0.3.0</Version>
+		<Version>0.4.0</Version>
 		<Authors>Pedro Sakuma</Authors>
 		<Company>Pedro Sakuma</Company>
 		<Product>SBE Source Generator</Product>


### PR DESCRIPTION
## Release v0.4.0

### Changed
- **Single-pass XmlReader parser**: `XmlDocument` DOM → forward-only `XmlReader` + `ParsedSchema` DTOs
- **LINQ elimination**: `Where/Select/ToList` → `foreach` loops with pre-sized lists
- **String interpolation → chained Append**: Reduced GC pressure in code generation
- **Collection pre-sizing**: Pre-sized all Dictionary, List, StringBuilder allocations
- **Cast caching**: Cached typed group/data lists in MessageDefinition
- **Dead code removal**: Removed legacy `SchemaParser.cs`

### Performance
~2.4x throughput improvement (2.5ms → ~1.07ms per schema iteration)

---
Triggers `publish.yml` pipeline on merge + GitHub Release creation.