### PR TITLE
feat: support sinceVersion/deprecated on enum and set values

### DIFF
--- a/src/SbeCodeGenerator/Generators/Fields/EnumFieldDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Fields/EnumFieldDefinition.cs
@@ -1,4 +1,4 @@
 ﻿namespace SbeSourceGenerator
 {
-    public record EnumFieldDefinition(string Name, string Description, string Value);
+    public record EnumFieldDefinition(string Name, string Description, string Value, string SinceVersion = "", string Deprecated = "");
 }

--- a/src/SbeCodeGenerator/Generators/Types/EnumDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Types/EnumDefinition.cs
@@ -15,7 +15,20 @@ namespace SbeSourceGenerator
             foreach (var field in Fields)
             {
                 if (field.Description != "")
-                    sb.AppendSummary(Description, tabs, nameof(EnumDefinition));
+                    sb.AppendSummary(field.Description, tabs, nameof(EnumDefinition));
+                else if (!string.IsNullOrEmpty(field.SinceVersion))
+                {
+                    sb.AppendTabs(tabs).AppendLine("/// <summary>");
+                    sb.AppendTabs(tabs).Append("/// Since version ").AppendLine(field.SinceVersion);
+                    sb.AppendTabs(tabs).AppendLine("/// </summary>");
+                }
+                if (!string.IsNullOrEmpty(field.Deprecated))
+                {
+                    var msg = string.IsNullOrEmpty(field.SinceVersion)
+                        ? "This value is deprecated"
+                        : $"This value is deprecated since version {field.SinceVersion}";
+                    sb.AppendTabs(tabs).Append("[Obsolete(\"").Append(msg).AppendLine("\")]");
+                }
                 sb.AppendTabs(tabs).Append(field.Name).Append(" = ").Append(IncludeQuotationAndCastIfNeeded(field.Value, EncodingType)).AppendLine(",");
             }
             sb.AppendLine("}", --tabs);

--- a/src/SbeCodeGenerator/Generators/Types/EnumFlagsDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Types/EnumFlagsDefinition.cs
@@ -17,7 +17,20 @@ namespace SbeSourceGenerator
             foreach (var field in Fields)
             {
                 if (field.Description != "")
-                    sb.AppendSummary(Description, tabs, nameof(EnumFlagsDefinition));
+                    sb.AppendSummary(field.Description, tabs, nameof(EnumFlagsDefinition));
+                else if (!string.IsNullOrEmpty(field.SinceVersion))
+                {
+                    sb.AppendTabs(tabs).AppendLine("/// <summary>");
+                    sb.AppendTabs(tabs).Append("/// Since version ").AppendLine(field.SinceVersion);
+                    sb.AppendTabs(tabs).AppendLine("/// </summary>");
+                }
+                if (!string.IsNullOrEmpty(field.Deprecated))
+                {
+                    var msg = string.IsNullOrEmpty(field.SinceVersion)
+                        ? "This value is deprecated"
+                        : $"This value is deprecated since version {field.SinceVersion}";
+                    sb.AppendTabs(tabs).Append("[Obsolete(\"").Append(msg).AppendLine("\")]");
+                }
 
                 string fieldValue = GetFlagValueLiteral(EncodingType, field.Value);
                 sb.AppendTabs(tabs).Append(field.Name).Append(" = ").Append(fieldValue).AppendLine(",");

--- a/src/SbeCodeGenerator/Generators/TypesCodeGenerator.cs
+++ b/src/SbeCodeGenerator/Generators/TypesCodeGenerator.cs
@@ -90,7 +90,9 @@ namespace SbeSourceGenerator.Generators
                 .Select(x => new EnumFieldDefinition(
                     x.choice.Name,
                     x.choice.Description,
-                    x.parsedValue?.ToString() ?? "0"
+                    x.parsedValue?.ToString() ?? "0",
+                    x.choice.SinceVersion,
+                    x.choice.Deprecated
                 ))
                 .ToList();
 
@@ -242,7 +244,9 @@ namespace SbeSourceGenerator.Generators
                         .Select(choice => new EnumFieldDefinition(
                             choice.Name,
                             choice.Description,
-                            choice.InnerText
+                            choice.InnerText,
+                            choice.SinceVersion,
+                            choice.Deprecated
                         ))
                         .ToList()
                 ),
@@ -257,7 +261,9 @@ namespace SbeSourceGenerator.Generators
                         .Select(choice => new EnumFieldDefinition(
                             choice.Name,
                             choice.Description,
-                            choice.InnerText
+                            choice.InnerText,
+                            choice.SinceVersion,
+                            choice.Deprecated
                         ))
                         .ToList()
                 )

--- a/tests/SbeCodeGenerator.Tests/TypesCodeGeneratorTests.cs
+++ b/tests/SbeCodeGenerator.Tests/TypesCodeGeneratorTests.cs
@@ -219,6 +219,104 @@ namespace SbeCodeGenerator.Tests
             Assert.Contains("HighBit", setResult.content);
         }
 
+        [Fact]
+        public void Generate_WithEnum_DeprecatedValue_GeneratesObsoleteAttribute()
+        {
+            var generator = new TypesCodeGenerator();
+            var context = new SchemaContext("test-schema");
+            var schema = SchemaReader.Parse(@"
+                <messageSchema>
+                    <types>
+                        <enum name='OrderType' encodingType='uint8'>
+                            <validValue name='Market'>0</validValue>
+                            <validValue name='Limit'>1</validValue>
+                            <validValue name='StopLoss' deprecated='2'>2</validValue>
+                        </enum>
+                    </types>
+                </messageSchema>");
+
+            var results = generator.Generate("TestNamespace", schema, context, default(SourceProductionContext));
+
+            var resultList = results.ToList();
+            var enumResult = resultList.FirstOrDefault(r => r.name.Contains("OrderType"));
+            Assert.NotEqual(default, enumResult);
+            Assert.Contains("[Obsolete(", enumResult.content);
+            Assert.Contains("StopLoss", enumResult.content);
+            Assert.DoesNotContain("[Obsolete(", enumResult.content.Split("Market")[0]);
+        }
+
+        [Fact]
+        public void Generate_WithEnum_SinceVersionOnValue_GeneratesVersionComment()
+        {
+            var generator = new TypesCodeGenerator();
+            var context = new SchemaContext("test-schema");
+            var schema = SchemaReader.Parse(@"
+                <messageSchema>
+                    <types>
+                        <enum name='Side' encodingType='uint8'>
+                            <validValue name='Buy'>0</validValue>
+                            <validValue name='Sell'>1</validValue>
+                            <validValue name='SellShort' sinceVersion='2'>2</validValue>
+                        </enum>
+                    </types>
+                </messageSchema>");
+
+            var results = generator.Generate("TestNamespace", schema, context, default(SourceProductionContext));
+
+            var resultList = results.ToList();
+            var enumResult = resultList.FirstOrDefault(r => r.name.Contains("Side"));
+            Assert.NotEqual(default, enumResult);
+            Assert.Contains("Since version 2", enumResult.content);
+        }
+
+        [Fact]
+        public void Generate_WithEnum_DeprecatedWithSinceVersion_GeneratesDetailedObsolete()
+        {
+            var generator = new TypesCodeGenerator();
+            var context = new SchemaContext("test-schema");
+            var schema = SchemaReader.Parse(@"
+                <messageSchema>
+                    <types>
+                        <enum name='TimeInForce' encodingType='uint8'>
+                            <validValue name='Day'>0</validValue>
+                            <validValue name='GoodTillCancel' sinceVersion='1' deprecated='3'>1</validValue>
+                        </enum>
+                    </types>
+                </messageSchema>");
+
+            var results = generator.Generate("TestNamespace", schema, context, default(SourceProductionContext));
+
+            var resultList = results.ToList();
+            var enumResult = resultList.FirstOrDefault(r => r.name.Contains("TimeInForce"));
+            Assert.NotEqual(default, enumResult);
+            Assert.Contains("[Obsolete(\"This value is deprecated since version 1\")]", enumResult.content);
+        }
+
+        [Fact]
+        public void Generate_WithSet_DeprecatedChoice_GeneratesObsoleteAttribute()
+        {
+            var generator = new TypesCodeGenerator();
+            var context = new SchemaContext("test-schema");
+            var schema = SchemaReader.Parse(@"
+                <messageSchema>
+                    <types>
+                        <set name='Capabilities' encodingType='uint8'>
+                            <choice name='Read'>0</choice>
+                            <choice name='Write'>1</choice>
+                            <choice name='Legacy' deprecated='2'>2</choice>
+                        </set>
+                    </types>
+                </messageSchema>");
+
+            var results = generator.Generate("TestNamespace", schema, context, default(SourceProductionContext));
+
+            var resultList = results.ToList();
+            var setResult = resultList.FirstOrDefault(r => r.name.Contains("Capabilities"));
+            Assert.NotEqual(default, setResult);
+            Assert.Contains("[Obsolete(", setResult.content);
+            Assert.Contains("Legacy", setResult.content);
+        }
+
         // ===== Phase 1 Feature Tests =====
 
         [Fact]


### PR DESCRIPTION
## Summary

Propagates sinceVersion and deprecated attributes from schema `<validValue>` and `<choice>` elements to generated C# code.

## Changes
- **EnumFieldDefinition.cs**: Added `SinceVersion` and `Deprecated` properties (backward-compatible defaults)
- **EnumDefinition.cs**: Generates `[Obsolete]` and version XML doc comments per value
- **EnumFlagsDefinition.cs**: Same for set choices
- **TypesCodeGenerator.cs**: Passes attributes from SchemaFieldDto through to definitions
- **TypesCodeGeneratorTests.cs**: 4 new tests

Also fixed a pre-existing bug where `EnumDefinition` used the enum-level `Description` instead of `field.Description` for per-value summaries.

## Test Results
115/115 unit tests pass ✅ (including all 7 snapshot tests)

Closes #94