### PR TITLE
feat: support sinceVersion on data elements

### DIFF
--- a/src/SbeCodeGenerator/Generators/MessagesCodeGenerator.cs
+++ b/src/SbeCodeGenerator/Generators/MessagesCodeGenerator.cs
@@ -55,7 +55,7 @@ namespace SbeSourceGenerator.Generators
                         fieldsForVersion,
                         BuildConstants(messageDto.Constants, context),
                         BuildGroups(messageDto.Groups, versionNamespace, context, sourceContext),
-                        BuildData(messageDto.Data, context)
+                        GetDataForVersion(messageDto.Data, version, context)
                     );
                     int estimatedCapacity = 2048 + fieldsForVersion.Count * 256
                         + messageDto.Groups.Count * 1024 + messageDto.Data.Count * 512;
@@ -97,6 +97,27 @@ namespace SbeSourceGenerator.Generators
                             "sinceVersion",
                             field.SinceVersion,
                             field.Name));
+                    }
+                }
+            }
+
+            foreach (var data in messageDto.Data)
+            {
+                if (!string.IsNullOrEmpty(data.SinceVersion))
+                {
+                    if (int.TryParse(data.SinceVersion, out int sinceVersion))
+                    {
+                        for (int v = 0; v <= sinceVersion; v++)
+                            versions.Add(v);
+                    }
+                    else if (sourceContext.CancellationToken != default)
+                    {
+                        sourceContext.ReportDiagnostic(Diagnostic.Create(
+                            SbeDiagnostics.InvalidIntegerAttribute,
+                            Location.None,
+                            "sinceVersion",
+                            data.SinceVersion,
+                            data.Name));
                     }
                 }
             }
@@ -289,9 +310,19 @@ namespace SbeSourceGenerator.Generators
 
         private static List<IFileContentGenerator> BuildData(List<SchemaDataDto> dataList, SchemaContext context)
         {
+            return GetDataForVersion(dataList, int.MaxValue, context);
+        }
+
+        private static List<IFileContentGenerator> GetDataForVersion(List<SchemaDataDto> dataList, int version, SchemaContext context)
+        {
             var result = new List<IFileContentGenerator>(dataList.Count);
             foreach (var data in dataList)
             {
+                if (!string.IsNullOrEmpty(data.SinceVersion)
+                    && int.TryParse(data.SinceVersion, out int sinceVersion)
+                    && sinceVersion > version)
+                    continue;
+
                 result.Add(new DataFieldDefinition(
                     TypeTranslator.NormalizeName(data.Name),
                     data.Id,

--- a/src/SbeCodeGenerator/Schema/SchemaDataDto.cs
+++ b/src/SbeCodeGenerator/Schema/SchemaDataDto.cs
@@ -7,6 +7,7 @@ namespace SbeSourceGenerator.Schema
         string Name,
         string Id,
         string Type,
-        string Description
+        string Description,
+        string SinceVersion = ""
     );
 }

--- a/src/SbeCodeGenerator/Schema/SchemaReader.cs
+++ b/src/SbeCodeGenerator/Schema/SchemaReader.cs
@@ -279,11 +279,12 @@ namespace SbeSourceGenerator.Schema
             string dataId = GetRequiredAttribute(reader, "id", "data", sourceContext);
             string type = GetRequiredAttribute(reader, "type", "data", sourceContext);
             string desc = reader.GetAttribute("description") ?? "";
+            string sinceVersion = reader.GetAttribute("sinceVersion") ?? "";
 
             if (!reader.IsEmptyElement)
                 reader.Skip();
 
-            return new SchemaDataDto(name, dataId, type, desc);
+            return new SchemaDataDto(name, dataId, type, desc, sinceVersion);
         }
 
         private static SchemaFieldDto ReadField(XmlReader reader, SourceProductionContext sourceContext)

--- a/tests/SbeCodeGenerator.Tests/MessagesCodeGeneratorTests.cs
+++ b/tests/SbeCodeGenerator.Tests/MessagesCodeGeneratorTests.cs
@@ -238,5 +238,50 @@ namespace SbeCodeGenerator.Tests
             Assert.Contains("(uint)", messageResult.content);
         }
 
+        [Fact]
+        public void Generate_WithDataSinceVersion_ExcludesDataFromEarlierVersions()
+        {
+            var schema = SchemaReader.Parse(@"
+                <sbe:messageSchema xmlns:sbe='http://fixprotocol.io/2016/sbe'
+                                   package='test' id='1' version='0'>
+                    <types>
+                        <composite name='MessageHeader'>
+                            <type name='blockLength' primitiveType='uint16'/>
+                            <type name='templateId' primitiveType='uint16'/>
+                            <type name='schemaId' primitiveType='uint16'/>
+                            <type name='version' primitiveType='uint16'/>
+                        </composite>
+                        <composite name='VarString8'>
+                            <type name='length' primitiveType='uint8'/>
+                            <type name='varData' length='0' primitiveType='uint8'/>
+                        </composite>
+                    </types>
+                    <sbe:message name='Order' id='1' description='Order message'>
+                        <field name='orderId' id='1' type='uint64'/>
+                        <data name='symbol' id='2' type='VarString8'/>
+                        <data name='memo' id='3' type='VarString8' sinceVersion='1'/>
+                    </sbe:message>
+                </sbe:messageSchema>");
+
+            var context = new SchemaContext("test-schema");
+            var typesGenerator = new TypesCodeGenerator();
+            _ = typesGenerator.Generate("TestNamespace", schema, context, default(SourceProductionContext)).ToList();
+
+            var generator = new MessagesCodeGenerator();
+            var results = generator.Generate("TestNamespace", schema, context, default(SourceProductionContext)).ToList();
+
+            // V0 should have symbol but NOT memo
+            var v0Result = results.FirstOrDefault(r => r.name.Contains("Order") && !r.name.Contains("V1"));
+            Assert.NotEqual(default, v0Result);
+            Assert.Contains("Symbol", v0Result.content);
+            Assert.DoesNotContain("Memo", v0Result.content);
+
+            // V1 should have both symbol and memo
+            var v1Result = results.FirstOrDefault(r => r.name.Contains("V1") && r.name.Contains("Order"));
+            Assert.NotEqual(default, v1Result);
+            Assert.Contains("Symbol", v1Result.content);
+            Assert.Contains("Memo", v1Result.content);
+        }
+
     }
 }


### PR DESCRIPTION
Parses sinceVersion from `<data>` elements and filters them by version when generating versioned messages. V0 excludes data with sinceVersion > 0.

## Changes
- **SchemaDataDto.cs**: Add SinceVersion property
- **SchemaReader.cs**: Parse sinceVersion in ReadData()
- **MessagesCodeGenerator.cs**: Update GetMessageVersions() + add GetDataForVersion()
- **MessagesCodeGeneratorTests.cs**: New test

116/116 unit tests pass ✅

Closes #95