### PR TITLE
feat: respect explicit blockLength attribute on messages

### DIFF
--- a/src/SbeCodeGenerator/Generators/MessagesCodeGenerator.cs
+++ b/src/SbeCodeGenerator/Generators/MessagesCodeGenerator.cs
@@ -55,7 +55,8 @@ namespace SbeSourceGenerator.Generators
                         fieldsForVersion,
                         BuildConstants(messageDto.Constants, context),
                         BuildGroups(messageDto.Groups, versionNamespace, context, sourceContext),
-                        GetDataForVersion(messageDto.Data, version, context)
+                        GetDataForVersion(messageDto.Data, version, context),
+                        messageDto.BlockLength
                     );
                     int estimatedCapacity = 2048 + fieldsForVersion.Count * 256
                         + messageDto.Groups.Count * 1024 + messageDto.Data.Count * 512;

--- a/src/SbeCodeGenerator/Generators/Types/MessageDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Types/MessageDefinition.cs
@@ -6,7 +6,7 @@ namespace SbeSourceGenerator
 {
     public record MessageDefinition(string Namespace, string RuntimeNamespace, string Name, string Id, string Description, string SemanticType, string Deprecated,
         List<IFileContentGenerator> Fields, List<IFileContentGenerator> Constants,
-        List<IFileContentGenerator> Groups, List<IFileContentGenerator> Datas) : IFileContentGenerator
+        List<IFileContentGenerator> Groups, List<IFileContentGenerator> Datas, string SchemaBlockLength = "") : IFileContentGenerator
     {
         private List<GroupDefinition>? _typedGroups;
         private List<DataFieldDefinition>? _typedDatas;
@@ -71,7 +71,7 @@ namespace SbeSourceGenerator
             sb.AppendLine("[MethodImpl(MethodImplOptions.AggressiveInlining)]", tabs);
             sb.AppendTabs(tabs).Append("public static bool TryParse(ReadOnlySpan<byte> buffer, out ").Append(Name).AppendLine("Data message, out ReadOnlySpan<byte> variableData)");
             sb.AppendLine("{", tabs++);
-            sb.AppendTabs(tabs).AppendLine("return TryParse(buffer, MESSAGE_SIZE, out message, out variableData);");
+            sb.AppendTabs(tabs).AppendLine("return TryParse(buffer, BLOCK_LENGTH, out message, out variableData);");
             sb.AppendLine("}", --tabs);
 
             // TryParse with blockLength parameter for schema evolution support
@@ -304,6 +304,13 @@ namespace SbeSourceGenerator
                 Id.ToString()).AppendFileContent(sb, tabs);
             new ConstantMessageFieldDefinition("MessageSize", "Size", "int", "Message Size",
                 Fields.SumFieldLength().ToString()).AppendFileContent(sb, tabs);
+
+            string blockLengthValue = !string.IsNullOrEmpty(SchemaBlockLength)
+                ? SchemaBlockLength
+                : "MESSAGE_SIZE";
+            new ConstantMessageFieldDefinition("BlockLength", "BlockLength", "int",
+                "Block length for wire protocol",
+                blockLengthValue).AppendFileContent(sb, tabs);
         }
 
         private void AppendConstantsFileContent(StringBuilder sb, int tabs)

--- a/src/SbeCodeGenerator/Schema/SchemaMessageDto.cs
+++ b/src/SbeCodeGenerator/Schema/SchemaMessageDto.cs
@@ -14,6 +14,7 @@ namespace SbeSourceGenerator.Schema
         List<SchemaFieldDto> Fields,
         List<SchemaFieldDto> Constants,
         List<SchemaGroupDto> Groups,
-        List<SchemaDataDto> Data
+        List<SchemaDataDto> Data,
+        string BlockLength = ""
     );
 }

--- a/src/SbeCodeGenerator/Schema/SchemaReader.cs
+++ b/src/SbeCodeGenerator/Schema/SchemaReader.cs
@@ -199,6 +199,7 @@ namespace SbeSourceGenerator.Schema
             string desc = reader.GetAttribute("description") ?? "";
             string semanticType = reader.GetAttribute("semanticType") ?? "";
             string deprecated = reader.GetAttribute("deprecated") ?? "";
+            string blockLengthAttr = reader.GetAttribute("blockLength") ?? "";
 
             var fields = new List<SchemaFieldDto>(16);
             var constants = new List<SchemaFieldDto>(4);
@@ -234,7 +235,7 @@ namespace SbeSourceGenerator.Schema
                 }
             }
 
-            return new SchemaMessageDto(name, msgId, desc, semanticType, deprecated, fields, constants, groups, data);
+            return new SchemaMessageDto(name, msgId, desc, semanticType, deprecated, fields, constants, groups, data, blockLengthAttr);
         }
 
         private static SchemaGroupDto ReadGroup(XmlReader reader, SourceProductionContext sourceContext)

--- a/tests/SbeCodeGenerator.Tests/MessagesCodeGeneratorTests.cs
+++ b/tests/SbeCodeGenerator.Tests/MessagesCodeGeneratorTests.cs
@@ -283,5 +283,50 @@ namespace SbeCodeGenerator.Tests
             Assert.Contains("Memo", v1Result.content);
         }
 
+        [Fact]
+        public void Generate_WithExplicitBlockLength_UsesSchemaBlockLength()
+        {
+            var schema = SchemaReader.Parse(@"
+                <sbe:messageSchema xmlns:sbe='http://fixprotocol.io/2016/sbe'
+                                   package='test' id='1' version='0'>
+                    <sbe:message name='PaddedMessage' id='1' blockLength='32' description='Message with padding'>
+                        <field name='orderId' id='1' type='uint64'/>
+                        <field name='price' id='2' type='int64'/>
+                    </sbe:message>
+                </sbe:messageSchema>");
+
+            var context = new SchemaContext("test-schema");
+            var generator = new MessagesCodeGenerator();
+            var results = generator.Generate("TestNamespace", schema, context, default(SourceProductionContext)).ToList();
+
+            var msgResult = results.FirstOrDefault(r => r.name.Contains("PaddedMessage"));
+            Assert.NotEqual(default, msgResult);
+            // MESSAGE_SIZE should be 16 (8+8), but BLOCK_LENGTH should be 32
+            Assert.Contains("BLOCK_LENGTH = 32", msgResult.content);
+            Assert.Contains("MESSAGE_SIZE = 16", msgResult.content);
+        }
+
+        [Fact]
+        public void Generate_WithoutExplicitBlockLength_BlockLengthEqualsMessageSize()
+        {
+            var schema = SchemaReader.Parse(@"
+                <sbe:messageSchema xmlns:sbe='http://fixprotocol.io/2016/sbe'
+                                   package='test' id='1' version='0'>
+                    <sbe:message name='NormalMessage' id='1' description='Normal message'>
+                        <field name='orderId' id='1' type='uint64'/>
+                        <field name='price' id='2' type='int64'/>
+                    </sbe:message>
+                </sbe:messageSchema>");
+
+            var context = new SchemaContext("test-schema");
+            var generator = new MessagesCodeGenerator();
+            var results = generator.Generate("TestNamespace", schema, context, default(SourceProductionContext)).ToList();
+
+            var msgResult = results.FirstOrDefault(r => r.name.Contains("NormalMessage"));
+            Assert.NotEqual(default, msgResult);
+            // BLOCK_LENGTH should equal MESSAGE_SIZE when not explicitly set
+            Assert.Contains("BLOCK_LENGTH = MESSAGE_SIZE", msgResult.content);
+        }
+
     }
 }

--- a/tests/SbeCodeGenerator.Tests/Snapshots/MessagesCodeGenerator.Message.Quote.verified.txt
+++ b/tests/SbeCodeGenerator.Tests/Snapshots/MessagesCodeGenerator.Message.Quote.verified.txt
@@ -21,6 +21,11 @@ public partial struct QuoteData
 	/// </summary>
 	public const int MESSAGE_SIZE = 32;
 	/// <summary>
+	/// Block length for wire protocol
+	/// (ConstantMessageFieldDefinition)
+	/// </summary>
+	public const int BLOCK_LENGTH = MESSAGE_SIZE;
+	/// <summary>
 	/// 
 	/// (MessageFieldDefinition)
 	/// </summary>
@@ -47,7 +52,7 @@ public partial struct QuoteData
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public static bool TryParse(ReadOnlySpan<byte> buffer, out QuoteData message, out ReadOnlySpan<byte> variableData)
 	{
-		return TryParse(buffer, MESSAGE_SIZE, out message, out variableData);
+		return TryParse(buffer, BLOCK_LENGTH, out message, out variableData);
 	}
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public static bool TryParse(ReadOnlySpan<byte> buffer, int blockLength, out QuoteData message, out ReadOnlySpan<byte> variableData)

--- a/tests/SbeCodeGenerator.Tests/Snapshots/MessagesCodeGenerator.Message.Trade.verified.txt
+++ b/tests/SbeCodeGenerator.Tests/Snapshots/MessagesCodeGenerator.Message.Trade.verified.txt
@@ -21,6 +21,11 @@ public partial struct TradeData
 	/// </summary>
 	public const int MESSAGE_SIZE = 25;
 	/// <summary>
+	/// Block length for wire protocol
+	/// (ConstantMessageFieldDefinition)
+	/// </summary>
+	public const int BLOCK_LENGTH = MESSAGE_SIZE;
+	/// <summary>
 	/// 
 	/// (MessageFieldDefinition)
 	/// </summary>
@@ -47,7 +52,7 @@ public partial struct TradeData
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public static bool TryParse(ReadOnlySpan<byte> buffer, out TradeData message, out ReadOnlySpan<byte> variableData)
 	{
-		return TryParse(buffer, MESSAGE_SIZE, out message, out variableData);
+		return TryParse(buffer, BLOCK_LENGTH, out message, out variableData);
 	}
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public static bool TryParse(ReadOnlySpan<byte> buffer, int blockLength, out TradeData message, out ReadOnlySpan<byte> variableData)


### PR DESCRIPTION
Parses blockLength from `<message>` elements and generates a `BLOCK_LENGTH` constant. When explicit, uses schema value; otherwise defaults to `MESSAGE_SIZE`.

118/118 unit tests ✅ | 113/115 integration tests ✅ (2 pre-existing failures)

Closes #93