### PR TITLE
feat: use characterEncoding attribute for fixed-size char types

### DIFF
--- a/src/SbeCodeGenerator/Generators/Types/FixedSizeCharTypeDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Types/FixedSizeCharTypeDefinition.cs
@@ -3,8 +3,14 @@
 namespace SbeSourceGenerator
 {
     public record FixedSizeCharTypeDefinition(string Namespace, string Name, string Description,
-        int Length) : IFileContentGenerator, IBlittable
+        int Length, string CharacterEncoding = "") : IFileContentGenerator, IBlittable
     {
+        private string ResolvedEncoding => CharacterEncoding.ToUpperInvariant() switch
+        {
+            "UTF-8" or "UTF8" => "Encoding.UTF8",
+            _ => "Encoding.Latin1"
+        };
+
         public void AppendFileContent(StringBuilder sb, int tabs = 0)
         {
             if (Length == 0)
@@ -28,7 +34,7 @@ namespace SbeSourceGenerator
                 sb.AppendLine("{", tabs++);
                 sb.AppendLine("ReadOnlySpan<byte> span = this;", tabs);
                 sb.AppendTabs(tabs).AppendLine("var index = span.IndexOf((byte)0);");
-                sb.AppendTabs(tabs).Append("return System.Text.Encoding.Latin1.GetString(span.Slice(0, index == -1 ? ").Append(Length).AppendLine(" : index));");
+                sb.AppendTabs(tabs).Append("return System.Text.").Append(ResolvedEncoding).Append(".GetString(span.Slice(0, index == -1 ? ").Append(Length).AppendLine(" : index));");
                 sb.AppendLine("}", --tabs);
                 sb.AppendLine("}", --tabs);
             }

--- a/src/SbeCodeGenerator/Generators/TypesCodeGenerator.cs
+++ b/src/SbeCodeGenerator/Generators/TypesCodeGenerator.cs
@@ -151,7 +151,8 @@ namespace SbeSourceGenerator.Generators
                         ns,
                         generatedName,
                         typeDto.Description,
-                        lengthValue
+                        lengthValue,
+                        typeDto.CharacterEncoding
                     ),
                     (_, "optional") => new OptionalTypeDefinition(
                         ns,

--- a/src/SbeCodeGenerator/Schema/SchemaReader.cs
+++ b/src/SbeCodeGenerator/Schema/SchemaReader.cs
@@ -138,7 +138,7 @@ namespace SbeSourceGenerator.Schema
                 }
             }
 
-            return new SchemaTypeDto(name, desc, primitiveType, semanticType, presence, nullValue, length, innerText, minValue, maxValue);
+            return new SchemaTypeDto(name, desc, primitiveType, semanticType, presence, nullValue, length, innerText, minValue, maxValue, characterEncoding);
         }
 
         private static SchemaCompositeDto ReadComposite(XmlReader reader, SourceProductionContext sourceContext)

--- a/src/SbeCodeGenerator/Schema/SchemaTypeDto.cs
+++ b/src/SbeCodeGenerator/Schema/SchemaTypeDto.cs
@@ -13,6 +13,7 @@ namespace SbeSourceGenerator.Schema
         string Length,
         string InnerText,
         string MinValue,
-        string MaxValue
+        string MaxValue,
+        string CharacterEncoding = ""
     );
 }

--- a/tests/SbeCodeGenerator.Tests/TypesCodeGeneratorTests.cs
+++ b/tests/SbeCodeGenerator.Tests/TypesCodeGeneratorTests.cs
@@ -317,6 +317,64 @@ namespace SbeCodeGenerator.Tests
             Assert.Contains("Legacy", setResult.content);
         }
 
+        [Fact]
+        public void Generate_FixedSizeChar_WithUtf8Encoding_UsesUtf8()
+        {
+            var generator = new TypesCodeGenerator();
+            var context = new SchemaContext("test-schema");
+            var schema = SchemaReader.Parse(@"
+                <messageSchema>
+                    <types>
+                        <type name='Symbol' primitiveType='char' length='8' characterEncoding='UTF-8'/>
+                    </types>
+                </messageSchema>");
+
+            var results = generator.Generate("TestNamespace", schema, context, default(SourceProductionContext));
+            var resultList = results.ToList();
+            var typeResult = resultList.FirstOrDefault(r => r.name.Contains("Symbol"));
+            Assert.NotEqual(default, typeResult);
+            Assert.Contains("Encoding.UTF8", typeResult.content);
+            Assert.DoesNotContain("Encoding.Latin1", typeResult.content);
+        }
+
+        [Fact]
+        public void Generate_FixedSizeChar_WithAsciiEncoding_UsesLatin1()
+        {
+            var generator = new TypesCodeGenerator();
+            var context = new SchemaContext("test-schema");
+            var schema = SchemaReader.Parse(@"
+                <messageSchema>
+                    <types>
+                        <type name='Exchange' primitiveType='char' length='4' characterEncoding='US-ASCII'/>
+                    </types>
+                </messageSchema>");
+
+            var results = generator.Generate("TestNamespace", schema, context, default(SourceProductionContext));
+            var resultList = results.ToList();
+            var typeResult = resultList.FirstOrDefault(r => r.name.Contains("Exchange"));
+            Assert.NotEqual(default, typeResult);
+            Assert.Contains("Encoding.Latin1", typeResult.content);
+        }
+
+        [Fact]
+        public void Generate_FixedSizeChar_NoEncoding_DefaultsToLatin1()
+        {
+            var generator = new TypesCodeGenerator();
+            var context = new SchemaContext("test-schema");
+            var schema = SchemaReader.Parse(@"
+                <messageSchema>
+                    <types>
+                        <type name='Ticker' primitiveType='char' length='6'/>
+                    </types>
+                </messageSchema>");
+
+            var results = generator.Generate("TestNamespace", schema, context, default(SourceProductionContext));
+            var resultList = results.ToList();
+            var typeResult = resultList.FirstOrDefault(r => r.name.Contains("Ticker"));
+            Assert.NotEqual(default, typeResult);
+            Assert.Contains("Encoding.Latin1", typeResult.content);
+        }
+
         // ===== Phase 1 Feature Tests =====
 
         [Fact]


### PR DESCRIPTION
Stores characterEncoding from schema and uses the correct Encoding in generated ToString(): UTF-8 → Encoding.UTF8, everything else → Encoding.Latin1 (default per SBE spec).

121/121 unit tests ✅

Closes #96