### PR TITLE
feat: support variable-width length prefix for varData (VarString16/32)

### DIFF
--- a/src/SbeCodeGenerator/Generators/Fields/DataFieldDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Fields/DataFieldDefinition.cs
@@ -2,8 +2,15 @@
 
 namespace SbeSourceGenerator.Generators.Fields
 {
-    public record DataFieldDefinition(string Name, string Id, string Type, string Description) : IFileContentGenerator
+    public record DataFieldDefinition(string Name, string Id, string Type, string Description, string LengthPrefixType = "byte") : IFileContentGenerator
     {
+        public int MaxLength => LengthPrefixType switch
+        {
+            "ushort" => 65535,
+            "uint" => int.MaxValue, // practical limit
+            _ => 255
+        };
+
         public void AppendFileContent(StringBuilder sb, int tabs = 0)
         {
         }

--- a/src/SbeCodeGenerator/Generators/MessagesCodeGenerator.cs
+++ b/src/SbeCodeGenerator/Generators/MessagesCodeGenerator.cs
@@ -324,11 +324,17 @@ namespace SbeSourceGenerator.Generators
                     && sinceVersion > version)
                     continue;
 
+                var lengthPrefixType = "byte";
+                var lengthKey = $"{data.Type}.length";
+                if (context.CompositeFieldTypes.TryGetValue(lengthKey, out var resolvedLengthType))
+                    lengthPrefixType = resolvedLengthType;
+
                 result.Add(new DataFieldDefinition(
                     TypeTranslator.NormalizeName(data.Name),
                     data.Id,
                     ResolveTypeName(data.Type, context),
-                    data.Description
+                    data.Description,
+                    lengthPrefixType
                 ));
             }
             return result;

--- a/src/SbeCodeGenerator/Generators/Types/MessageDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Types/MessageDefinition.cs
@@ -235,11 +235,11 @@ namespace SbeSourceGenerator
                 sb.AppendLine("/// </summary>", tabs);
                 sb.AppendTabs(tabs).Append("private static bool TryEncode").Append(data.Name.FirstCharToUpper()).AppendLine("(ref SpanWriter writer, ReadOnlySpan<byte> data)");
                 sb.AppendLine("{", tabs++);
-                sb.AppendTabs(tabs).AppendLine("// Write length prefix (uint8 for VarString8)");
-                sb.AppendTabs(tabs).AppendLine("if (data.Length > 255)");
+                sb.AppendTabs(tabs).Append("// Write length prefix (").Append(data.LengthPrefixType).AppendLine(")");
+                sb.AppendTabs(tabs).Append("if (data.Length > ").Append(data.MaxLength).AppendLine(")");
                 sb.AppendLine("    return false;", tabs + 1);
                 sb.AppendLine("", tabs);
-                sb.AppendLine("if (!writer.TryWrite((byte)data.Length))", tabs);
+                sb.AppendTabs(tabs).Append("if (!writer.TryWrite((").Append(data.LengthPrefixType).AppendLine(")data.Length))");
                 sb.AppendLine("    return false;", tabs + 1);
                 sb.AppendLine("", tabs);
                 sb.AppendTabs(tabs).AppendLine("// Write data bytes");

--- a/tests/SbeCodeGenerator.Tests/MessagesCodeGeneratorTests.cs
+++ b/tests/SbeCodeGenerator.Tests/MessagesCodeGeneratorTests.cs
@@ -328,5 +328,44 @@ namespace SbeCodeGenerator.Tests
             Assert.Contains("BLOCK_LENGTH = MESSAGE_SIZE", msgResult.content);
         }
 
+        [Fact]
+        public void Generate_WithVarString16_UsesUshortLengthPrefix()
+        {
+            var schema = SchemaReader.Parse(@"
+                <sbe:messageSchema xmlns:sbe='http://fixprotocol.io/2016/sbe'
+                                   package='test' id='1' version='0'>
+                    <types>
+                        <composite name='MessageHeader'>
+                            <type name='blockLength' primitiveType='uint16'/>
+                            <type name='templateId' primitiveType='uint16'/>
+                            <type name='schemaId' primitiveType='uint16'/>
+                            <type name='version' primitiveType='uint16'/>
+                        </composite>
+                        <composite name='VarString16'>
+                            <type name='length' primitiveType='uint16'/>
+                            <type name='varData' length='0' primitiveType='uint8'/>
+                        </composite>
+                    </types>
+                    <sbe:message name='LargeMessage' id='1' description='Message with large varData'>
+                        <field name='id' id='1' type='uint64'/>
+                        <data name='payload' id='2' type='VarString16'/>
+                    </sbe:message>
+                </sbe:messageSchema>");
+
+            var context = new SchemaContext("test-schema");
+            var typesGenerator = new TypesCodeGenerator();
+            _ = typesGenerator.Generate("TestNamespace", schema, context, default(SourceProductionContext)).ToList();
+
+            var generator = new MessagesCodeGenerator();
+            var results = generator.Generate("TestNamespace", schema, context, default(SourceProductionContext)).ToList();
+
+            var msgResult = results.FirstOrDefault(r => r.name.Contains("LargeMessage"));
+            Assert.NotEqual(default, msgResult);
+            // Should use ushort cast and 65535 max, NOT byte/255
+            Assert.Contains("(ushort)data.Length", msgResult.content);
+            Assert.Contains("65535", msgResult.content);
+            Assert.DoesNotContain("(byte)data.Length", msgResult.content);
+        }
+
     }
 }


### PR DESCRIPTION
Closes #97

## Changes

Resolves the composite length field type from `SchemaContext.CompositeFieldTypes` to determine the varData length prefix type dynamically instead of hardcoding `byte`/`255`.

### Files changed:
- **DataFieldDefinition.cs**: Added `LengthPrefixType` property (default `byte`) with `MaxLength` helper that maps to the correct max value per type
- **MessagesCodeGenerator.cs**: Looks up `{compositeType}.length` in `CompositeFieldTypes` to resolve the prefix type for each data field
- **MessageDefinition.cs**: Uses dynamic prefix type and max value in `TryEncode` helpers instead of hardcoded `(byte)data.Length`/`255`
- **MessagesCodeGeneratorTests.cs**: New test verifying VarString16 composite generates `ushort` cast and `65535` max

### Testing
- 122 unit tests pass (121 existing + 1 new)
- Default VarString8 behavior preserved (byte prefix)