### PR TITLE
feat: support <ref> element inside composite types

### DIFF
--- a/src/SbeCodeGenerator/Generators/Fields/CompositeRefFieldDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Fields/CompositeRefFieldDefinition.cs
@@ -1,0 +1,17 @@
+﻿using System.Text;
+
+namespace SbeSourceGenerator
+{
+    /// <summary>
+    /// Represents a <ref/> element inside a composite, embedding a referenced composite type as a field.
+    /// </summary>
+    public record CompositeRefFieldDefinition(string Name, string Description, string TypeName, int Length)
+        : IFileContentGenerator, IBlittable
+    {
+        public void AppendFileContent(StringBuilder sb, int tabs = 0)
+        {
+            sb.AppendSummary(Description, tabs, nameof(CompositeRefFieldDefinition));
+            sb.AppendTabs(tabs).Append("public ").Append(TypeName).Append(" ").Append(Name).AppendLine(";");
+        }
+    }
+}

--- a/src/SbeCodeGenerator/Generators/TypesCodeGenerator.cs
+++ b/src/SbeCodeGenerator/Generators/TypesCodeGenerator.cs
@@ -282,8 +282,16 @@ namespace SbeSourceGenerator.Generators
         {
             var generatedName = RegisterGeneratedTypeName(context, compositeDto.Name);
 
-            // Pre-translate all field primitive types once to avoid repeated dictionary lookups
-            var fieldTranslations = compositeDto.Fields
+            // Separate ref fields from primitive fields
+            var refFields = compositeDto.Fields
+                .Where(f => string.IsNullOrEmpty(f.PrimitiveType) && !string.IsNullOrEmpty(f.Type))
+                .ToList();
+            var primitiveFields = compositeDto.Fields
+                .Where(f => !string.IsNullOrEmpty(f.PrimitiveType))
+                .ToList();
+
+            // Pre-translate primitive field types
+            var fieldTranslations = primitiveFields
                 .Select(f => new { Field = f, Translation = TypeTranslator.Translate(f.PrimitiveType) })
                 .ToList();
 
@@ -304,13 +312,21 @@ namespace SbeSourceGenerator.Generators
                 }
             }
 
-            var generator = new CompositeDefinition(
-                ns,
-                generatedName,
-                compositeDto.Description,
-                compositeDto.SemanticType,
-                fieldTranslations
-                    .Select(ft => (IFileContentGenerator)((ft.Field.Presence, ft.Field.Length) switch
+            // Register ref fields in CompositeFieldTypes
+            foreach (var rf in refFields)
+            {
+                var resolvedRefType = ResolveTypeName(rf.Type, context);
+                context.CompositeFieldTypes[$"{compositeDto.Name}.{rf.Name}"] = resolvedRefType;
+            }
+
+            // Build field definitions preserving original order
+            var fields = new List<IFileContentGenerator>(compositeDto.Fields.Count);
+            foreach (var field in compositeDto.Fields)
+            {
+                if (!string.IsNullOrEmpty(field.PrimitiveType))
+                {
+                    var ft = fieldTranslations.First(x => x.Field == field);
+                    fields.Add((ft.Field.Presence, ft.Field.Length) switch
                     {
                         ("constant", _) => new ConstantTypeFieldDefinition(
                             TypeTranslator.NormalizeName(ft.Field.Name),
@@ -331,14 +347,33 @@ namespace SbeSourceGenerator.Generators
                             ft.Field.Description,
                             "byte"
                         ),
-                        _ => new ValueFieldDefinition(
+                        _ => (IFileContentGenerator)new ValueFieldDefinition(
                             TypeTranslator.NormalizeName(ft.Field.Name),
                             ft.Field.Description,
                             ResolveTypeName(ft.Translation.PrimitiveType, context),
                             GetTypeLength(ft.Translation.PrimitiveType, context)
                         )
-                    }))
-                    .ToList()
+                    });
+                }
+                else if (!string.IsNullOrEmpty(field.Type))
+                {
+                    var resolvedRefType = ResolveTypeName(field.Type, context);
+                    var refLength = context.CustomTypeLengths.TryGetValue(field.Type, out var len) ? len : 0;
+                    fields.Add(new CompositeRefFieldDefinition(
+                        TypeTranslator.NormalizeName(field.Name),
+                        field.Description,
+                        resolvedRefType,
+                        refLength
+                    ));
+                }
+            }
+
+            var generator = new CompositeDefinition(
+                ns,
+                generatedName,
+                compositeDto.Description,
+                compositeDto.SemanticType,
+                fields
             );
             if (generator.Fields.All(f => f is IBlittable))
                 context.CustomTypeLengths[compositeDto.Name] = generator.Fields.SumFieldLength();

--- a/tests/SbeCodeGenerator.Tests/TypesCodeGeneratorTests.cs
+++ b/tests/SbeCodeGenerator.Tests/TypesCodeGeneratorTests.cs
@@ -630,5 +630,63 @@ namespace SbeCodeGenerator.Tests
             // Should have StructLayout attribute for blittable types
             Assert.Contains("[StructLayout(LayoutKind.Sequential, Pack = 1)]", compositeResult.content);
         }
+
+        [Fact]
+        public void Generate_WithRefInComposite_EmbedsReferencedType()
+        {
+            var generator = new TypesCodeGenerator();
+            var context = new SchemaContext("test-schema");
+            var schema = SchemaReader.Parse(@"
+                <messageSchema>
+                    <types>
+                        <composite name='Booster' description='Turbo booster'>
+                            <type name='boostType' primitiveType='char'/>
+                            <type name='horsePower' primitiveType='uint16'/>
+                        </composite>
+                        <composite name='Engine' description='Engine details'>
+                            <type name='capacity' primitiveType='uint16'/>
+                            <type name='numCylinders' primitiveType='uint8'/>
+                            <ref name='booster' type='Booster'/>
+                        </composite>
+                    </types>
+                </messageSchema>");
+
+            var results = generator.Generate("TestNamespace", schema, context, default(SourceProductionContext)).ToList();
+
+            var engineResult = results.FirstOrDefault(r => r.name.Contains("Engine"));
+            Assert.NotEqual(default, engineResult);
+            // Should embed Booster as a field
+            Assert.Contains("public Booster Booster;", engineResult.content);
+            // Engine should be blittable (all fields fixed-size)
+            Assert.Contains("[StructLayout(LayoutKind.Sequential, Pack = 1)]", engineResult.content);
+            // MESSAGE_SIZE should include Booster size (1 char + 2 uint16 = 3) + capacity(2) + numCylinders(1) = 6
+            Assert.Contains("MESSAGE_SIZE = 6;", engineResult.content);
+        }
+
+        [Fact]
+        public void Generate_WithRefInComposite_RegistersCompositeFieldType()
+        {
+            var generator = new TypesCodeGenerator();
+            var context = new SchemaContext("test-schema");
+            var schema = SchemaReader.Parse(@"
+                <messageSchema>
+                    <types>
+                        <composite name='Decimal' description='Decimal value'>
+                            <type name='mantissa' primitiveType='int64'/>
+                            <type name='exponent' primitiveType='int8'/>
+                        </composite>
+                        <composite name='Quote' description='Quote with ref'>
+                            <type name='price' primitiveType='uint64'/>
+                            <ref name='decimal' type='Decimal'/>
+                        </composite>
+                    </types>
+                </messageSchema>");
+
+            var results = generator.Generate("TestNamespace", schema, context, default(SourceProductionContext)).ToList();
+
+            // The ref field should be registered in CompositeFieldTypes
+            Assert.True(context.CompositeFieldTypes.ContainsKey("Quote.decimal"));
+            Assert.Equal("Decimal", context.CompositeFieldTypes["Quote.decimal"]);
+        }
     }
 }


### PR DESCRIPTION
Closes #88

## Changes

Adds support for `<ref>` elements inside `<composite>` types, per SBE 1.0 spec. This allows composites to embed other composites by reference.

### Example
```xml
<composite name="Engine">
    <type name="capacity" primitiveType="uint16"/>
    <ref name="booster" type="Booster"/>
</composite>
```
Generates:
```csharp
public partial struct Engine {
    public ushort Capacity;
    public Booster Booster;
}
```

### Files changed:
- **New: CompositeRefFieldDefinition.cs** — `IBlittable` field definition for `<ref>` elements
- **TypesCodeGenerator.cs** — Refactored `GenerateComposite()` to detect ref fields, resolve type names/sizes from context, and preserve field order
- **TypesCodeGeneratorTests.cs** — 2 new tests

### Testing
- 124 unit tests pass (122 existing + 2 new)