### PR TITLE
feat: support <data> (variable-length fields) inside groups

### DIFF
--- a/src/SbeCodeGenerator/Generators/MessagesCodeGenerator.cs
+++ b/src/SbeCodeGenerator/Generators/MessagesCodeGenerator.cs
@@ -303,7 +303,8 @@ namespace SbeSourceGenerator.Generators
                     group.Description,
                     groupFields,
                     groupConstants,
-                    numInGroupType
+                    numInGroupType,
+                    group.Data != null ? BuildData(group.Data, context) : null
                 ));
             }
             return result;

--- a/src/SbeCodeGenerator/Generators/Types/GroupDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Types/GroupDefinition.cs
@@ -1,11 +1,33 @@
 ﻿using System.Collections.Generic;
 using System.Text;
+using SbeSourceGenerator.Generators.Fields;
 
 namespace SbeSourceGenerator
 {
     public record GroupDefinition(string Namespace, string Name, string Id, string DimensionType, string Description,
-        List<IFileContentGenerator> Fields, List<IFileContentGenerator> Constants, string NumInGroupType = "ushort") : IFileContentGenerator
+        List<IFileContentGenerator> Fields, List<IFileContentGenerator> Constants,
+        string NumInGroupType = "ushort", List<IFileContentGenerator>? Datas = null) : IFileContentGenerator
     {
+        private List<DataFieldDefinition>? _typedDatas;
+
+        public List<DataFieldDefinition> TypedDatas
+        {
+            get
+            {
+                if (_typedDatas == null)
+                {
+                    _typedDatas = new List<DataFieldDefinition>();
+                    if (Datas != null)
+                    {
+                        foreach (var item in Datas)
+                            _typedDatas.Add((DataFieldDefinition)item);
+                    }
+                }
+                return _typedDatas;
+            }
+        }
+
+        public bool HasGroupData => Datas != null && Datas.Count > 0;
         public void AppendFileContent(StringBuilder sb, int tabs = 0)
         {
             sb.AppendStructDefinition(tabs, Description, Name, nameof(GroupDefinition));

--- a/src/SbeCodeGenerator/Generators/Types/MessageDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Types/MessageDefinition.cs
@@ -280,6 +280,13 @@ namespace SbeSourceGenerator
                     sb.AppendLine("break;", tabs);
                     sb.AppendLine("}", --tabs);
                     sb.AppendTabs(tabs).Append("callback").Append(group.Name).AppendLine("(data);");
+                    // Read group-level variable data after each entry
+                    foreach (var groupData in group.TypedDatas)
+                    {
+                        sb.AppendTabs(tabs).Append("var datas").Append(groupData.Name).Append(" = ").Append(groupData.Type).AppendLine(".Create(reader.Remaining);");
+                        sb.AppendTabs(tabs).Append("callback").Append(group.Name).Append(groupData.Name).Append("(datas").Append(groupData.Name).AppendLine(");");
+                        sb.AppendTabs(tabs).Append("reader.TrySkip(datas").Append(groupData.Name).AppendLine(".TotalLength);");
+                    }
                     sb.AppendLine("}", --tabs);
                     sb.AppendLine("}", --tabs);
                 }
@@ -540,7 +547,11 @@ namespace SbeSourceGenerator
         {
             var parts = new List<string>(TypedGroups.Count + TypedDatas.Count);
             foreach (var group in TypedGroups)
+            {
                 parts.Add($"Action<{group.Name}Data> callback{group.Name}");
+                foreach (var groupData in group.TypedDatas)
+                    parts.Add($"{groupData.Type}.Callback callback{group.Name}{groupData.Name}");
+            }
             foreach (var data in TypedDatas)
                 parts.Add($"{data.Type}.Callback callback{data.Name}");
             return string.Join(", ", parts);
@@ -550,7 +561,11 @@ namespace SbeSourceGenerator
         {
             var parts = new List<string>(TypedGroups.Count + TypedDatas.Count);
             foreach (var group in TypedGroups)
+            {
                 parts.Add($"callback{group.Name}");
+                foreach (var groupData in group.TypedDatas)
+                    parts.Add($"callback{group.Name}{groupData.Name}");
+            }
             foreach (var data in TypedDatas)
                 parts.Add($"callback{data.Name}");
             return string.Join(", ", parts);

--- a/src/SbeCodeGenerator/Schema/SchemaGroupDto.cs
+++ b/src/SbeCodeGenerator/Schema/SchemaGroupDto.cs
@@ -11,6 +11,7 @@ namespace SbeSourceGenerator.Schema
         string DimensionType,
         string Description,
         List<SchemaFieldDto> Fields,
-        List<SchemaFieldDto> Constants
+        List<SchemaFieldDto> Constants,
+        List<SchemaDataDto>? Data = null
     );
 }

--- a/src/SbeCodeGenerator/Schema/SchemaReader.cs
+++ b/src/SbeCodeGenerator/Schema/SchemaReader.cs
@@ -283,6 +283,7 @@ namespace SbeSourceGenerator.Schema
 
             var fields = new List<SchemaFieldDto>(16);
             var constants = new List<SchemaFieldDto>(4);
+            var dataList = new List<SchemaDataDto>();
 
             if (!reader.IsEmptyElement)
             {
@@ -302,10 +303,15 @@ namespace SbeSourceGenerator.Schema
                         else
                             fields.Add(field);
                     }
+                    else if (reader.LocalName == "data")
+                    {
+                        dataList.Add(ReadData(reader, sourceContext));
+                    }
                 }
             }
 
-            return new SchemaGroupDto(name, groupId, dimensionType, desc, fields, constants);
+            return new SchemaGroupDto(name, groupId, dimensionType, desc, fields, constants,
+                dataList.Count > 0 ? dataList : null);
         }
 
         private static SchemaDataDto ReadData(XmlReader reader, SourceProductionContext sourceContext)

--- a/tests/SbeCodeGenerator.Tests/MessagesCodeGeneratorTests.cs
+++ b/tests/SbeCodeGenerator.Tests/MessagesCodeGeneratorTests.cs
@@ -367,5 +367,51 @@ namespace SbeCodeGenerator.Tests
             Assert.DoesNotContain("(byte)data.Length", msgResult.content);
         }
 
+        [Fact]
+        public void Generate_WithDataInsideGroup_GeneratesGroupDataCallbacks()
+        {
+            var schema = SchemaReader.Parse(@"
+                <sbe:messageSchema xmlns:sbe='http://fixprotocol.io/2016/sbe'
+                                   package='test' id='1' version='0'>
+                    <types>
+                        <composite name='MessageHeader'>
+                            <type name='blockLength' primitiveType='uint16'/>
+                            <type name='templateId' primitiveType='uint16'/>
+                            <type name='schemaId' primitiveType='uint16'/>
+                            <type name='version' primitiveType='uint16'/>
+                        </composite>
+                        <composite name='GroupSizeEncoding'>
+                            <type name='blockLength' primitiveType='uint16'/>
+                            <type name='numInGroup' primitiveType='uint16'/>
+                        </composite>
+                        <composite name='VarString8'>
+                            <type name='length' primitiveType='uint8'/>
+                            <type name='varData' length='0' primitiveType='uint8'/>
+                        </composite>
+                    </types>
+                    <sbe:message name='OrderMessage' id='1' description='Order with group data'>
+                        <field name='id' id='1' type='uint64'/>
+                        <group name='orders' id='2' dimensionType='GroupSizeEncoding'>
+                            <field name='orderId' id='3' type='uint64'/>
+                            <data name='notes' id='4' type='VarString8'/>
+                        </group>
+                    </sbe:message>
+                </sbe:messageSchema>");
+
+            var context = new SchemaContext("test-schema");
+            var typesGenerator = new TypesCodeGenerator();
+            _ = typesGenerator.Generate("TestNamespace", schema, context, default(SourceProductionContext)).ToList();
+
+            var generator = new MessagesCodeGenerator();
+            var results = generator.Generate("TestNamespace", schema, context, default(SourceProductionContext)).ToList();
+
+            var msgResult = results.FirstOrDefault(r => r.name.Contains("OrderMessage"));
+            Assert.NotEqual(default, msgResult);
+            // Group data callback should be in ConsumeVariableLengthSegments signature
+            Assert.Contains("callbackOrdersNotes", msgResult.content);
+            // Group data should be read inside the group loop (after reading group entry)
+            Assert.Contains("VarString8.Create", msgResult.content);
+        }
+
     }
 }


### PR DESCRIPTION
Closes #91

## Changes

Per SBE spec, `<group>` extends `blockType` and can contain `<data>` elements (variable-length fields). This PR adds parsing and code generation for group-level data.

### Wire format with group data:
```
[group header] [entry1 fixed block] [entry1 data] [entry2 fixed block] [entry2 data] ...
```

### Files changed:
- **SchemaGroupDto.cs** — Added optional `Data` list
- **SchemaReader.cs** — `ReadGroup()` now parses `<data>` child elements
- **GroupDefinition.cs** — Added `Datas` property with `TypedDatas` accessor
- **MessagesCodeGenerator.cs** — `BuildGroups()` passes group data through
- **MessageDefinition.cs** — Group data callbacks in `ConsumeVariableLengthSegments`, group data read after each entry with `reader.TrySkip` advancement

### Testing
- 127 unit tests pass (126 existing + 1 new)