### PR TITLE
feat: support nested groups (groups within groups)

### DIFF
--- a/src/SbeCodeGenerator/Generators/MessagesCodeGenerator.cs
+++ b/src/SbeCodeGenerator/Generators/MessagesCodeGenerator.cs
@@ -304,7 +304,8 @@ namespace SbeSourceGenerator.Generators
                     groupFields,
                     groupConstants,
                     numInGroupType,
-                    group.Data != null ? BuildData(group.Data, context) : null
+                    group.Data != null ? BuildData(group.Data, context) : null,
+                    group.Groups != null ? BuildGroups(group.Groups, versionNamespace, context, sourceContext) : null
                 ));
             }
             return result;

--- a/src/SbeCodeGenerator/Generators/Types/GroupDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Types/GroupDefinition.cs
@@ -6,9 +6,11 @@ namespace SbeSourceGenerator
 {
     public record GroupDefinition(string Namespace, string Name, string Id, string DimensionType, string Description,
         List<IFileContentGenerator> Fields, List<IFileContentGenerator> Constants,
-        string NumInGroupType = "ushort", List<IFileContentGenerator>? Datas = null) : IFileContentGenerator
+        string NumInGroupType = "ushort", List<IFileContentGenerator>? Datas = null,
+        List<IFileContentGenerator>? NestedGroups = null) : IFileContentGenerator
     {
         private List<DataFieldDefinition>? _typedDatas;
+        private List<GroupDefinition>? _typedNestedGroups;
 
         public List<DataFieldDefinition> TypedDatas
         {
@@ -27,7 +29,25 @@ namespace SbeSourceGenerator
             }
         }
 
+        public List<GroupDefinition> TypedNestedGroups
+        {
+            get
+            {
+                if (_typedNestedGroups == null)
+                {
+                    _typedNestedGroups = new List<GroupDefinition>();
+                    if (NestedGroups != null)
+                    {
+                        foreach (var item in NestedGroups)
+                            _typedNestedGroups.Add((GroupDefinition)item);
+                    }
+                }
+                return _typedNestedGroups;
+            }
+        }
+
         public bool HasGroupData => Datas != null && Datas.Count > 0;
+        public bool HasNestedGroups => NestedGroups != null && NestedGroups.Count > 0;
         public void AppendFileContent(StringBuilder sb, int tabs = 0)
         {
             sb.AppendStructDefinition(tabs, Description, Name, nameof(GroupDefinition));

--- a/src/SbeCodeGenerator/Generators/Types/MessageDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Types/MessageDefinition.cs
@@ -271,24 +271,7 @@ namespace SbeSourceGenerator
                 sb.AppendLine("{", tabs++);
                 foreach (var group in TypedGroups)
                 {
-                    sb.AppendTabs(tabs).Append("if (reader.TryRead<").Append(group.DimensionType).Append(">(out var group").Append(group.Name).AppendLine("))");
-                    sb.AppendLine("{", tabs++);
-                    sb.AppendTabs(tabs).Append("for (int i = 0; i < group").Append(group.Name).AppendLine(".NumInGroup; i++)");
-                    sb.AppendLine("{", tabs++);
-                    sb.AppendTabs(tabs).Append("if (!reader.TryRead<").Append(group.Name).AppendLine("Data>(out var data))");
-                    sb.AppendLine("{", tabs++);
-                    sb.AppendLine("break;", tabs);
-                    sb.AppendLine("}", --tabs);
-                    sb.AppendTabs(tabs).Append("callback").Append(group.Name).AppendLine("(data);");
-                    // Read group-level variable data after each entry
-                    foreach (var groupData in group.TypedDatas)
-                    {
-                        sb.AppendTabs(tabs).Append("var datas").Append(groupData.Name).Append(" = ").Append(groupData.Type).AppendLine(".Create(reader.Remaining);");
-                        sb.AppendTabs(tabs).Append("callback").Append(group.Name).Append(groupData.Name).Append("(datas").Append(groupData.Name).AppendLine(");");
-                        sb.AppendTabs(tabs).Append("reader.TrySkip(datas").Append(groupData.Name).AppendLine(".TotalLength);");
-                    }
-                    sb.AppendLine("}", --tabs);
-                    sb.AppendLine("}", --tabs);
+                    AppendGroupConsume(sb, tabs, group);
                 }
                 foreach (var data in TypedDatas)
                 {
@@ -299,10 +282,46 @@ namespace SbeSourceGenerator
             }
         }
 
+        private static void AppendGroupConsume(StringBuilder sb, int tabs, GroupDefinition group)
+        {
+            sb.AppendTabs(tabs).Append("if (reader.TryRead<").Append(group.DimensionType).Append(">(out var group").Append(group.Name).AppendLine("))");
+            sb.AppendLine("{", tabs++);
+            sb.AppendTabs(tabs).Append("for (int i = 0; i < group").Append(group.Name).AppendLine(".NumInGroup; i++)");
+            sb.AppendLine("{", tabs++);
+            sb.AppendTabs(tabs).Append("if (!reader.TryRead<").Append(group.Name).AppendLine("Data>(out var data))");
+            sb.AppendLine("{", tabs++);
+            sb.AppendLine("break;", tabs);
+            sb.AppendLine("}", --tabs);
+            sb.AppendTabs(tabs).Append("callback").Append(group.Name).AppendLine("(data);");
+            // Read group-level variable data after each entry
+            foreach (var groupData in group.TypedDatas)
+            {
+                sb.AppendTabs(tabs).Append("var datas").Append(groupData.Name).Append(" = ").Append(groupData.Type).AppendLine(".Create(reader.Remaining);");
+                sb.AppendTabs(tabs).Append("callback").Append(group.Name).Append(groupData.Name).Append("(datas").Append(groupData.Name).AppendLine(");");
+                sb.AppendTabs(tabs).Append("reader.TrySkip(datas").Append(groupData.Name).AppendLine(".TotalLength);");
+            }
+            // Read nested groups recursively
+            foreach (var nestedGroup in group.TypedNestedGroups)
+            {
+                AppendGroupConsume(sb, tabs, nestedGroup);
+            }
+            sb.AppendLine("}", --tabs);
+            sb.AppendLine("}", --tabs);
+        }
+
         private void AppendGroupsFileContent(StringBuilder sb, int tabs)
         {
             foreach (var group in Groups)
+            {
                 group.AppendFileContent(sb, tabs);
+                // Also generate nested group structs
+                var typedGroup = (GroupDefinition)group;
+                if (typedGroup.HasNestedGroups)
+                {
+                    foreach (var nested in typedGroup.NestedGroups!)
+                        nested.AppendFileContent(sb, tabs);
+                }
+            }
         }
 
         private void AppendMessageDefinitionConstants(StringBuilder sb, int tabs)
@@ -547,28 +566,38 @@ namespace SbeSourceGenerator
         {
             var parts = new List<string>(TypedGroups.Count + TypedDatas.Count);
             foreach (var group in TypedGroups)
-            {
-                parts.Add($"Action<{group.Name}Data> callback{group.Name}");
-                foreach (var groupData in group.TypedDatas)
-                    parts.Add($"{groupData.Type}.Callback callback{group.Name}{groupData.Name}");
-            }
+                AppendGroupCallbackParams(parts, group);
             foreach (var data in TypedDatas)
                 parts.Add($"{data.Type}.Callback callback{data.Name}");
             return string.Join(", ", parts);
+        }
+
+        private static void AppendGroupCallbackParams(List<string> parts, GroupDefinition group)
+        {
+            parts.Add($"Action<{group.Name}Data> callback{group.Name}");
+            foreach (var groupData in group.TypedDatas)
+                parts.Add($"{groupData.Type}.Callback callback{group.Name}{groupData.Name}");
+            foreach (var nestedGroup in group.TypedNestedGroups)
+                AppendGroupCallbackParams(parts, nestedGroup);
         }
 
         private string BuildCallbackArgs()
         {
             var parts = new List<string>(TypedGroups.Count + TypedDatas.Count);
             foreach (var group in TypedGroups)
-            {
-                parts.Add($"callback{group.Name}");
-                foreach (var groupData in group.TypedDatas)
-                    parts.Add($"callback{group.Name}{groupData.Name}");
-            }
+                AppendGroupCallbackArgs(parts, group);
             foreach (var data in TypedDatas)
                 parts.Add($"callback{data.Name}");
             return string.Join(", ", parts);
+        }
+
+        private static void AppendGroupCallbackArgs(List<string> parts, GroupDefinition group)
+        {
+            parts.Add($"callback{group.Name}");
+            foreach (var groupData in group.TypedDatas)
+                parts.Add($"callback{group.Name}{groupData.Name}");
+            foreach (var nestedGroup in group.TypedNestedGroups)
+                AppendGroupCallbackArgs(parts, nestedGroup);
         }
     }
 }

--- a/src/SbeCodeGenerator/Schema/SchemaGroupDto.cs
+++ b/src/SbeCodeGenerator/Schema/SchemaGroupDto.cs
@@ -12,6 +12,7 @@ namespace SbeSourceGenerator.Schema
         string Description,
         List<SchemaFieldDto> Fields,
         List<SchemaFieldDto> Constants,
-        List<SchemaDataDto>? Data = null
+        List<SchemaDataDto>? Data = null,
+        List<SchemaGroupDto>? Groups = null
     );
 }

--- a/src/SbeCodeGenerator/Schema/SchemaReader.cs
+++ b/src/SbeCodeGenerator/Schema/SchemaReader.cs
@@ -284,6 +284,7 @@ namespace SbeSourceGenerator.Schema
             var fields = new List<SchemaFieldDto>(16);
             var constants = new List<SchemaFieldDto>(4);
             var dataList = new List<SchemaDataDto>();
+            var nestedGroups = new List<SchemaGroupDto>();
 
             if (!reader.IsEmptyElement)
             {
@@ -307,11 +308,16 @@ namespace SbeSourceGenerator.Schema
                     {
                         dataList.Add(ReadData(reader, sourceContext));
                     }
+                    else if (reader.LocalName == "group")
+                    {
+                        nestedGroups.Add(ReadGroup(reader, sourceContext));
+                    }
                 }
             }
 
             return new SchemaGroupDto(name, groupId, dimensionType, desc, fields, constants,
-                dataList.Count > 0 ? dataList : null);
+                dataList.Count > 0 ? dataList : null,
+                nestedGroups.Count > 0 ? nestedGroups : null);
         }
 
         private static SchemaDataDto ReadData(XmlReader reader, SourceProductionContext sourceContext)

--- a/tests/SbeCodeGenerator.Tests/MessagesCodeGeneratorTests.cs
+++ b/tests/SbeCodeGenerator.Tests/MessagesCodeGeneratorTests.cs
@@ -413,5 +413,54 @@ namespace SbeCodeGenerator.Tests
             Assert.Contains("VarString8.Create", msgResult.content);
         }
 
+        [Fact]
+        public void Generate_WithNestedGroups_GeneratesNestedGroupCode()
+        {
+            var schema = SchemaReader.Parse(@"
+                <sbe:messageSchema xmlns:sbe='http://fixprotocol.io/2016/sbe'
+                                   package='test' id='1' version='0'>
+                    <types>
+                        <composite name='MessageHeader'>
+                            <type name='blockLength' primitiveType='uint16'/>
+                            <type name='templateId' primitiveType='uint16'/>
+                            <type name='schemaId' primitiveType='uint16'/>
+                            <type name='version' primitiveType='uint16'/>
+                        </composite>
+                        <composite name='GroupSizeEncoding'>
+                            <type name='blockLength' primitiveType='uint16'/>
+                            <type name='numInGroup' primitiveType='uint16'/>
+                        </composite>
+                    </types>
+                    <sbe:message name='CarMessage' id='1' description='Car with nested groups'>
+                        <field name='serialNumber' id='1' type='uint64'/>
+                        <group name='performanceFigures' id='2' dimensionType='GroupSizeEncoding'>
+                            <field name='octaneRating' id='3' type='uint8'/>
+                            <group name='acceleration' id='4' dimensionType='GroupSizeEncoding'>
+                                <field name='mph' id='5' type='uint16'/>
+                                <field name='seconds' id='6' type='uint32'/>
+                            </group>
+                        </group>
+                    </sbe:message>
+                </sbe:messageSchema>");
+
+            var context = new SchemaContext("test-schema");
+            var typesGenerator = new TypesCodeGenerator();
+            _ = typesGenerator.Generate("TestNamespace", schema, context, default(SourceProductionContext)).ToList();
+
+            var generator = new MessagesCodeGenerator();
+            var results = generator.Generate("TestNamespace", schema, context, default(SourceProductionContext)).ToList();
+
+            var msgResult = results.FirstOrDefault(r => r.name.Contains("CarMessage"));
+            Assert.NotEqual(default, msgResult);
+            // Should have callback for both outer group and nested group
+            Assert.Contains("callbackPerformanceFigures", msgResult.content);
+            Assert.Contains("callbackAcceleration", msgResult.content);
+            // Should generate both group data structs
+            Assert.Contains("PerformanceFiguresData", msgResult.content);
+            Assert.Contains("AccelerationData", msgResult.content);
+            // Nested group should read dimension header
+            Assert.Contains("TryRead<GroupSizeEncoding>(out var groupAcceleration)", msgResult.content);
+        }
+
     }
 }


### PR DESCRIPTION
Closes #90

## Changes

Adds support for nested `<group>` elements per SBE 1.0 spec. This enables multi-level repeating structures like the Real Logic Car example.

### Example
```xml
<group name="performanceFigures" id="12">
    <field name="octaneRating" id="13" type="uint8"/>
    <group name="acceleration" id="14">
        <field name="mph" id="15" type="uint16"/>
        <field name="seconds" id="16" type="uint32"/>
    </group>
</group>
```

### Files changed:
- **SchemaGroupDto.cs** — Added optional `Groups` list
- **SchemaReader.cs** — `ReadGroup()` now parses nested `<group>` recursively
- **GroupDefinition.cs** — Added `NestedGroups` with `TypedNestedGroups` accessor
- **MessagesCodeGenerator.cs** — `BuildGroups()` recursively builds nested groups
- **MessageDefinition.cs** — Refactored to `AppendGroupConsume()` (recursive), nested group struct generation, recursive callback params/args

### Testing
- 128 unit tests pass (127 existing + 1 new)