### PR TITLE
feat: support custom headerType on messageSchema

### DIFF
--- a/src/SbeCodeGenerator/SBESourceGenerator.cs
+++ b/src/SbeCodeGenerator/SBESourceGenerator.cs
@@ -78,6 +78,9 @@ namespace SbeSourceGenerator
                             }
                         }
 
+                        if (!string.IsNullOrEmpty(schema.HeaderType))
+                            context.HeaderType = schema.HeaderType;
+
                         // Use specialized generators to handle different categories
                         var typesGenerator = new TypesCodeGenerator();
                         var messagesGenerator = new MessagesCodeGenerator();

--- a/src/SbeCodeGenerator/Schema/ParsedSchema.cs
+++ b/src/SbeCodeGenerator/Schema/ParsedSchema.cs
@@ -18,6 +18,7 @@ namespace SbeSourceGenerator.Schema
         List<SchemaCompositeDto> Composites,
         List<SchemaEnumDto> Enums,
         List<SchemaEnumDto> Sets,
-        List<SchemaMessageDto> Messages
+        List<SchemaMessageDto> Messages,
+        string HeaderType = "messageHeader"
     );
 }

--- a/src/SbeCodeGenerator/Schema/SchemaReader.cs
+++ b/src/SbeCodeGenerator/Schema/SchemaReader.cs
@@ -28,6 +28,7 @@ namespace SbeSourceGenerator.Schema
             string id = "";
             string description = "";
             string semanticVersion = "";
+            string headerType = "messageHeader";
 
             var settings = new XmlReaderSettings
             {
@@ -53,6 +54,7 @@ namespace SbeSourceGenerator.Schema
                             id = reader.GetAttribute("id") ?? "";
                             description = reader.GetAttribute("description") ?? "";
                             semanticVersion = reader.GetAttribute("semanticVersion") ?? "";
+                            headerType = reader.GetAttribute("headerType") ?? "messageHeader";
                             break;
 
                         case "types":
@@ -67,7 +69,7 @@ namespace SbeSourceGenerator.Schema
             }
 
             return new ParsedSchema(byteOrder, package, version, id, description, semanticVersion,
-                types, composites, enums, sets, messages);
+                types, composites, enums, sets, messages, headerType);
         }
 
         public static ParsedSchema Parse(string xmlContent)

--- a/src/SbeCodeGenerator/SchemaContext.cs
+++ b/src/SbeCodeGenerator/SchemaContext.cs
@@ -52,6 +52,12 @@ namespace SbeSourceGenerator
         /// </summary>
         public string ByteOrder { get; set; } = "littleEndian";
 
+        /// <summary>
+        /// The composite type name used for the message header.
+        /// Defaults to "messageHeader" per SBE spec.
+        /// </summary>
+        public string HeaderType { get; set; } = "messageHeader";
+
         public string CreateHintName(params string[] segments)
         {
             var builder = new StringBuilder(SchemaKey);

--- a/tests/SbeCodeGenerator.Tests/MessagesCodeGeneratorTests.cs
+++ b/tests/SbeCodeGenerator.Tests/MessagesCodeGeneratorTests.cs
@@ -462,5 +462,42 @@ namespace SbeCodeGenerator.Tests
             Assert.Contains("TryRead<GroupSizeEncoding>(out var groupAcceleration)", msgResult.content);
         }
 
+        [Fact]
+        public void Parse_WithCustomHeaderType_StoresHeaderTypeInSchema()
+        {
+            var schema = SchemaReader.Parse(@"
+                <sbe:messageSchema xmlns:sbe='http://fixprotocol.io/2016/sbe'
+                                   package='test' id='1' version='0'
+                                   headerType='customHeader'>
+                    <types>
+                        <composite name='customHeader' description='Custom header'>
+                            <type name='blockLength' primitiveType='uint32'/>
+                            <type name='templateId' primitiveType='uint16'/>
+                            <type name='schemaId' primitiveType='uint16'/>
+                            <type name='version' primitiveType='uint16'/>
+                        </composite>
+                    </types>
+                    <sbe:message name='TestMessage' id='1' description='Test'>
+                        <field name='id' id='1' type='uint64'/>
+                    </sbe:message>
+                </sbe:messageSchema>");
+
+            Assert.Equal("customHeader", schema.HeaderType);
+        }
+
+        [Fact]
+        public void Parse_WithDefaultHeaderType_UsesMessageHeader()
+        {
+            var schema = SchemaReader.Parse(@"
+                <sbe:messageSchema xmlns:sbe='http://fixprotocol.io/2016/sbe'
+                                   package='test' id='1' version='0'>
+                    <sbe:message name='TestMessage' id='1' description='Test'>
+                        <field name='id' id='1' type='uint64'/>
+                    </sbe:message>
+                </sbe:messageSchema>");
+
+            Assert.Equal("messageHeader", schema.HeaderType);
+        }
+
     }
 }


### PR DESCRIPTION
Closes #92

## Changes

Parses the `headerType` attribute from `<messageSchema>` per SBE 1.0 spec. Defaults to `"messageHeader"` when not specified.

### Files changed:
- **ParsedSchema.cs** — Added `HeaderType` property
- **SchemaReader.cs** — Parses `headerType` attribute  
- **SchemaContext.cs** — Added `HeaderType` property for downstream access
- **SBESourceGenerator.cs** — Wires headerType from schema to context
- **MessagesCodeGeneratorTests.cs** — 2 new tests

### Testing
- 130 unit tests pass (128 existing + 2 new)