### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-04-09
+
+### Changed
+- **Ancestor context in nested group callbacks**: Nested group callbacks now include parent data as additional type parameters, providing full hierarchical context. For example, `Action<PerformanceFiguresData, AccelerationData>` instead of `Action<AccelerationData>`. Scales to any nesting depth with all ancestor types known at compile time.
+
 ## [0.5.0] - 2025-07-25
 
 ### Added

--- a/src/SbeCodeGenerator/SbeSourceGenerator.csproj
+++ b/src/SbeCodeGenerator/SbeSourceGenerator.csproj
@@ -10,7 +10,7 @@
 		<NoWarn>$(NoWarn);CS1591</NoWarn>
 		<PackageId>SbeSourceGenerator</PackageId>
 		<Title>SBE Source Generator</Title>
-		<Version>0.5.0</Version>
+		<Version>0.6.0</Version>
 		<Authors>Pedro Sakuma</Authors>
 		<Company>Pedro Sakuma</Company>
 		<Product>SBE Source Generator</Product>


### PR DESCRIPTION
### v0.6.0

**Breaking change:** Nested group callbacks now include ancestor context.

- `Action<PerformanceFiguresData, AccelerationData>` instead of `Action<AccelerationData>`
- Callback invocation passes parent data: `callbackAcceleration(data, nestedData)`
- Scales to any nesting depth

See [CHANGELOG.md](CHANGELOG.md) for details.