### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-04-09
+
+### Removed
+- **Opinionated semantic type helpers**: Removed `DecimalSemanticTypeDefinition`, `LocalMktDateSemanticTypeDefinition`, `MonthYearSemanticTypeDefinition`, `UTCTimestampSemanticTypeDefinition`, and `NumberExtensions`. These were hardcoded to CME/B3 schema naming conventions, not driven by the SBE `semanticType` attribute. The generator now focuses on producing correct SBE structs; consumers can add extension methods for domain-specific conversions.
+
 ## [0.6.0] - 2026-04-09
 
 ### Changed

--- a/src/SbeCodeGenerator/SbeSourceGenerator.csproj
+++ b/src/SbeCodeGenerator/SbeSourceGenerator.csproj
@@ -10,7 +10,7 @@
 		<NoWarn>$(NoWarn);CS1591</NoWarn>
 		<PackageId>SbeSourceGenerator</PackageId>
 		<Title>SBE Source Generator</Title>
-		<Version>0.6.0</Version>
+		<Version>0.7.0</Version>
 		<Authors>Pedro Sakuma</Authors>
 		<Company>Pedro Sakuma</Company>
 		<Product>SBE Source Generator</Product>


### PR DESCRIPTION
### v0.7.0

**Breaking change:** Removed opinionated semantic type helpers (DecimalSemanticTypeDefinition, LocalMktDateSemanticTypeDefinition, MonthYearSemanticTypeDefinition, UTCTimestampSemanticTypeDefinition, NumberExtensions).

Generator now focuses purely on SBE spec compliance. Consumers can add extension methods for domain-specific conversions.