### PR TITLE
feat: support field-level nullValue override in messages

### DIFF
--- a/src/SbeCodeGenerator/Generators/Fields/OptionalMessageFieldDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Fields/OptionalMessageFieldDefinition.cs
@@ -13,9 +13,10 @@ namespace SbeSourceGenerator
         public int Length { get; }
         public string SinceVersion { get; }
         public string Deprecated { get; }
+        public string? NullValue { get; }
 
         public OptionalMessageFieldDefinition(string Name, string Id, string Type, string? PrimitiveType, string Description,
-            int? Offset, int Length, string SinceVersion = "", string Deprecated = "")
+            int? Offset, int Length, string SinceVersion = "", string Deprecated = "", string? NullValue = null)
         {
             this.Name = Name;
             this.Id = Id;
@@ -26,6 +27,7 @@ namespace SbeSourceGenerator
             this.Length = Length;
             this.SinceVersion = SinceVersion;
             this.Deprecated = Deprecated;
+            this.NullValue = NullValue;
         }
         public void AppendFileContent(StringBuilder sb, int tabs = 0)
         {
@@ -40,9 +42,9 @@ namespace SbeSourceGenerator
             sb.AppendTabs(tabs).Append("[FieldOffset(").Append(Offset).AppendLine(")]");
             if (PrimitiveType != null)
             {
-                var nullValue = TypesCatalog.GetNullValue(PrimitiveType);
+                var nullValue = NullValue ?? TypesCatalog.GetNullValue(PrimitiveType);
                 sb.AppendTabs(tabs).Append("private ").Append(Type).Append(" ").Append(Name.FirstCharToLower()).AppendLine(";");
-                if (TypesCatalog.IsFloatingPoint(PrimitiveType))
+                if (NullValue == null && TypesCatalog.IsFloatingPoint(PrimitiveType))
                 {
                     sb.AppendTabs(tabs).Append("public ").Append(Type).Append("? ").Append(Name).Append(" => ").Append(PrimitiveType).Append(".IsNaN((").Append(PrimitiveType).Append(")").Append(Name.FirstCharToLower()).Append(") ? null : ").Append(Name.FirstCharToLower()).AppendLine(";");
                     sb.AppendTabs(tabs).Append("public void Set").Append(Name).Append("(").Append(Type).Append("? value) => ").Append(Name.FirstCharToLower()).Append(" = value ?? (").Append(Type).Append(")").Append(nullValue).AppendLine(";");

--- a/src/SbeCodeGenerator/Generators/MessagesCodeGenerator.cs
+++ b/src/SbeCodeGenerator/Generators/MessagesCodeGenerator.cs
@@ -209,25 +209,28 @@ namespace SbeSourceGenerator.Generators
                 if (isOptional)
                 {
                     var underlyingType = GetUnderlyingType(field.Type, context);
-                    if (underlyingType != null && !TypesCatalog.HasNullValue(underlyingType)
+                    var effectivePrimitiveType = underlyingType ?? resolvedType;
+                    if (!TypesCatalog.HasNullValue(effectivePrimitiveType)
+                        && string.IsNullOrEmpty(field.NullValue)
                         && sourceContext.CancellationToken != default)
                     {
                         sourceContext.ReportDiagnostic(Diagnostic.Create(
                             SbeDiagnostics.UnknownPrimitiveTypeFallback,
                             Location.None,
-                            underlyingType, "null sentinel", field.Name));
+                            effectivePrimitiveType, "null sentinel", field.Name));
                     }
 
                     result.Add(new OptionalMessageFieldDefinition(
                         generatedFieldName,
                         field.Id,
                         resolvedType,
-                        underlyingType,
+                        effectivePrimitiveType,
                         field.Description,
                         ParseOffset(field.Offset, field.Name, sourceContext),
                         GetTypeLength(field.Type, context),
                         field.SinceVersion,
-                        field.Deprecated
+                        field.Deprecated,
+                        field.NullValue == "" ? null : field.NullValue
                     ));
                 }
                 else

--- a/tests/SbeCodeGenerator.Tests/MessagesCodeGeneratorTests.cs
+++ b/tests/SbeCodeGenerator.Tests/MessagesCodeGeneratorTests.cs
@@ -547,5 +547,29 @@ namespace SbeCodeGenerator.Tests
             Assert.Contains("callbackAcceleration(data, nestedData)", msgResult.content);
         }
 
+        [Fact]
+        public void Generate_WithFieldLevelNullValue_UsesCustomNullSentinel()
+        {
+            var generator = new MessagesCodeGenerator();
+            var context = new SchemaContext("test-schema");
+            var schema = SchemaReader.Parse(@"
+                <sbe:messageSchema xmlns:sbe='http://fixprotocol.io/2016/sbe'>
+                    <sbe:message name='OrderWithCustomNull' id='1'>
+                        <field name='orderId' id='1' type='uint64'/>
+                        <field name='price' id='2' type='int64' presence='optional' nullValue='0'/>
+                        <field name='quantity' id='3' type='int32' presence='optional' nullValue='-1'/>
+                    </sbe:message>
+                </sbe:messageSchema>");
+
+            var results = generator.Generate("TestNamespace", schema, context, default(SourceProductionContext)).ToList();
+            var msgResult = results.FirstOrDefault(r => r.name.Contains("OrderWithCustomNull"));
+            Assert.NotEqual(default, msgResult);
+
+            // Should use custom nullValue=0 instead of default -9223372036854775808L
+            Assert.Contains("== 0", msgResult.content);
+            // Should use custom nullValue=-1 instead of default -2147483648
+            Assert.Contains("== -1", msgResult.content);
+        }
+
     }
 }


### PR DESCRIPTION
### Problem
When a message field specifies `nullValue` attribute (e.g., `nullValue='0'`), the generator ignored it and always used the type catalog default sentinel.

Also, direct primitive fields with `presence='optional'` (not via custom optional type) didn't generate nullable accessors because `underlyingType` was null.

### Solution
- Pass `field.NullValue` through to `OptionalMessageFieldDefinition`
- Use `effectivePrimitiveType` (falls back to resolved type when underlying is null)
- Custom nullValue takes precedence over IsNaN check for float/double

### Tests
- 1 new unit test validating custom nullValue='0' and nullValue='-1'
- 133 unit tests pass, 112/114 integration (2 pre-existing)