### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2026-04-10
+
+### Added
+- **Big-endian byte order support**: Schemas with `byteOrder="bigEndian"` now generate correct endian-aware code. Multi-byte fields use property-based access with `BinaryPrimitives.ReverseEndianness()` conversions. Three generation modes: passthrough (same endianness), always-reverse (opposite), and conditional (safe default). Single-byte fields (byte, sbyte, char) are always passthrough.
+- **`SbeAssumeHostEndianness` MSBuild property**: Optional compile-time hint to eliminate runtime endian branching. Set to `LittleEndian` or `BigEndian` in your `.csproj` to generate branchless code when you know the target host architecture.
+- **Optional float/double fields**: Float and double fields with `presence="optional"` now use IEEE 754 NaN as the null sentinel, with `float.IsNaN()` / `double.IsNaN()` for null checks.
+- **Field-level nullValue override**: The `nullValue` attribute on message fields is now respected, overriding the default type-catalog sentinel value.
+- **SBE012 diagnostic**: Warning when `SbeAssumeHostEndianness` has an invalid value (not `LittleEndian` or `BigEndian`).
+- **SBE011 diagnostic**: Warning when set choice bit positions exceed encoding type width.
+
+### Changed
+- **SBE007 severity**: Reduced from Warning to Info — big-endian schemas are now fully supported; the diagnostic is informational only.
+- Removed obsolete `EndianHelpers` generated utility class (superseded by property-based endian conversion).
+- Removed out-of-scope integration tests (`SpanReaderIntegrationTests`, `ProposedFeaturesTests`, `DeprecatedFieldsIntegrationTests`) that tested internal utilities rather than SBE schema generation.
+
 ## [0.7.0] - 2026-04-09
 
 ### Removed

--- a/src/SbeCodeGenerator/AnalyzerReleases.Shipped.md
+++ b/src/SbeCodeGenerator/AnalyzerReleases.Shipped.md
@@ -1,3 +1,18 @@
+## Release 0.8.0
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+SBE011 | SbeSourceGenerator | Warning | Set choice bit position exceeds encoding type width.
+SBE012 | SbeSourceGenerator | Warning | Invalid SbeAssumeHostEndianness MSBuild property value.
+
+### Changed Rules
+
+Rule ID | New Category | New Severity | Old Severity | Notes
+--------|--------------|--------------|--------------|------
+SBE007 | SbeSourceGenerator | Info | Warning | Now informational — big-endian is fully supported with conditional byte swap.
+
 ## Release 0.3.0
 
 ### New Rules

--- a/src/SbeCodeGenerator/AnalyzerReleases.Unshipped.md
+++ b/src/SbeCodeGenerator/AnalyzerReleases.Unshipped.md
@@ -2,6 +2,3 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|------
-SBE007 | SbeSourceGenerator | Info | Big-endian schema with conditional byte swap (updated from Warning).
-SBE011 | SbeSourceGenerator | Warning | Set choice bit position exceeds encoding type width.
-SBE012 | SbeSourceGenerator | Warning | Invalid SbeAssumeHostEndianness MSBuild property value.

--- a/src/SbeCodeGenerator/SbeSourceGenerator.csproj
+++ b/src/SbeCodeGenerator/SbeSourceGenerator.csproj
@@ -10,7 +10,7 @@
 		<NoWarn>$(NoWarn);CS1591</NoWarn>
 		<PackageId>SbeSourceGenerator</PackageId>
 		<Title>SBE Source Generator</Title>
-		<Version>0.7.0</Version>
+		<Version>0.8.0</Version>
 		<Authors>Pedro Sakuma</Authors>
 		<Company>Pedro Sakuma</Company>
 		<Product>SBE Source Generator</Product>


### PR DESCRIPTION
## Release v0.8.0 — Full SBE 1.0 Spec Compliance

### What's New

- **Big-endian byte order support** — Property-based field access with `BinaryPrimitives.ReverseEndianness()` conversions. Three modes: passthrough, always-reverse, conditional.
- **`SbeAssumeHostEndianness` MSBuild hint** — Compile-time hint to eliminate runtime endian branching.
- **Optional float/double fields** — NaN null sentinel with `float.IsNaN()` / `double.IsNaN()`.
- **Field-level nullValue override** — `nullValue` attribute on message fields now works.
- **SBE011/SBE012 diagnostics** — New warnings for set bit overflow and invalid hint values.
- **SBE007 severity** reduced from Warning to Info.

### Cross-schema verification

SBE 1.0 does NOT support cross-schema (cross-file) type references. Our per-schema isolation is correct. Added test for multiple `<types>` blocks.

### Test Results

- 162 unit tests ✅
- 72 integration tests ✅ (2 pre-existing VersioningIntegrationTests failures)