### PR TITLE
refactor: extract shared type resolver and fix audit findings

### DIFF
--- a/src/SbeCodeGenerator/AnalyzerReleases.Shipped.md
+++ b/src/SbeCodeGenerator/AnalyzerReleases.Shipped.md
@@ -4,14 +4,9 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|------
+SBE007 | SbeSourceGenerator | Info | Big-endian schema with conditional byte swap (updated from Warning).
 SBE011 | SbeSourceGenerator | Warning | Set choice bit position exceeds encoding type width.
 SBE012 | SbeSourceGenerator | Warning | Invalid SbeAssumeHostEndianness MSBuild property value.
-
-### Changed Rules
-
-Rule ID | New Category | New Severity | Old Severity | Notes
---------|--------------|--------------|--------------|------
-SBE007 | SbeSourceGenerator | Info | Warning | Now informational — big-endian is fully supported with conditional byte swap.
 
 ## Release 0.3.0
 

--- a/src/SbeCodeGenerator/AnalyzerReleases.Unshipped.md
+++ b/src/SbeCodeGenerator/AnalyzerReleases.Unshipped.md
@@ -2,3 +2,5 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|------
+SBE013 | SbeSourceGenerator | Warning | Duplicate type name in schema.
+SBE014 | SbeSourceGenerator | Warning | sinceVersion exceeds schema version.

--- a/src/SbeCodeGenerator/Diagnostics/SbeDiagnostics.cs
+++ b/src/SbeCodeGenerator/Diagnostics/SbeDiagnostics.cs
@@ -127,5 +127,25 @@ namespace SbeSourceGenerator.Diagnostics
             defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
             description: "The SbeAssumeHostEndianness MSBuild property must be 'LittleEndian' or 'BigEndian'. Invalid values cause the generator to emit conditional runtime endianness checks.");
+
+        // SBE013: Duplicate type name
+        public static readonly DiagnosticDescriptor DuplicateTypeName = new DiagnosticDescriptor(
+            id: "SBE013",
+            title: "Duplicate type name",
+            messageFormat: "Type name '{0}' is defined more than once in the schema. The last definition will be used.",
+            category: Category,
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: "SBE type names must be unique within a schema. Duplicate definitions cause the generator to silently use the last one, which may produce unexpected results.");
+
+        // SBE014: sinceVersion exceeds schema version
+        public static readonly DiagnosticDescriptor SinceVersionExceedsSchemaVersion = new DiagnosticDescriptor(
+            id: "SBE014",
+            title: "sinceVersion exceeds schema version",
+            messageFormat: "Field '{0}' has sinceVersion={1} which exceeds the schema version ({2}). The field will never be included in any generated message version.",
+            category: Category,
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: "A field's sinceVersion attribute should not exceed the schema's version attribute. Such fields are unreachable and may indicate a schema authoring error.");
     }
 }

--- a/src/SbeCodeGenerator/Generators/MessagesCodeGenerator.cs
+++ b/src/SbeCodeGenerator/Generators/MessagesCodeGenerator.cs
@@ -2,7 +2,6 @@ using Microsoft.CodeAnalysis;
 using SbeSourceGenerator.Diagnostics;
 using SbeSourceGenerator.Generators.Fields;
 using SbeSourceGenerator.Schema;
-using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -13,30 +12,17 @@ namespace SbeSourceGenerator.Generators
     /// </summary>
     internal class MessagesCodeGenerator : ICodeGenerator
     {
-        private static readonly HashSet<string> DotNetPrimitiveTypes = new(StringComparer.Ordinal)
-        {
-            "bool",
-            "byte",
-            "sbyte",
-            "short",
-            "ushort",
-            "int",
-            "uint",
-            "long",
-            "ulong",
-            "float",
-            "double",
-            "char",
-            "string"
-        };
-
         public IEnumerable<(string name, string content)> Generate(string ns, ParsedSchema schema, SchemaContext context, SourceProductionContext sourceContext)
         {
+            int schemaVersion = -1;
+            if (!string.IsNullOrEmpty(schema.Version))
+                int.TryParse(schema.Version, out schemaVersion);
+
             foreach (var messageDto in schema.Messages)
             {
-                var generatedMessageName = RegisterGeneratedTypeName(context, messageDto.Name);
+                var generatedMessageName = TypeResolverHelper.RegisterGeneratedTypeName(context, messageDto.Name, sourceContext);
 
-                var versions = GetMessageVersions(messageDto, sourceContext);
+                var versions = GetMessageVersions(messageDto, schemaVersion, sourceContext);
                 var baseNamespace = StripSchemaVersion(ns);
 
                 foreach (var version in versions)
@@ -76,7 +62,7 @@ namespace SbeSourceGenerator.Generators
         /// Determines all versions needed for a message based on sinceVersion attributes.
         /// Returns a list like [0, 1, 2] for a message with fields at versions 0, 1, and 2.
         /// </summary>
-        private static List<int> GetMessageVersions(SchemaMessageDto messageDto, SourceProductionContext sourceContext)
+        private static List<int> GetMessageVersions(SchemaMessageDto messageDto, int schemaVersion, SourceProductionContext sourceContext)
         {
             var versions = new HashSet<int> { 0 }; // Always generate version 0
 
@@ -86,6 +72,16 @@ namespace SbeSourceGenerator.Generators
                 {
                     if (int.TryParse(field.SinceVersion, out int sinceVersion))
                     {
+                        if (schemaVersion >= 0 && sinceVersion > schemaVersion && sourceContext.CancellationToken != default)
+                        {
+                            sourceContext.ReportDiagnostic(Diagnostic.Create(
+                                SbeDiagnostics.SinceVersionExceedsSchemaVersion,
+                                Location.None,
+                                field.Name,
+                                sinceVersion.ToString(),
+                                schemaVersion.ToString()));
+                        }
+
                         for (int v = 0; v <= sinceVersion; v++)
                         {
                             versions.Add(v);
@@ -109,6 +105,16 @@ namespace SbeSourceGenerator.Generators
                 {
                     if (int.TryParse(data.SinceVersion, out int sinceVersion))
                     {
+                        if (schemaVersion >= 0 && sinceVersion > schemaVersion && sourceContext.CancellationToken != default)
+                        {
+                            sourceContext.ReportDiagnostic(Diagnostic.Create(
+                                SbeDiagnostics.SinceVersionExceedsSchemaVersion,
+                                Location.None,
+                                data.Name,
+                                sinceVersion.ToString(),
+                                schemaVersion.ToString()));
+                        }
+
                         for (int v = 0; v <= sinceVersion; v++)
                             versions.Add(v);
                     }
@@ -204,7 +210,7 @@ namespace SbeSourceGenerator.Generators
 
                 bool isOptional = field.Presence == "optional" || context.OptionalTypes.ContainsKey(field.Type);
                 var translated = TypeTranslator.Translate(field.Type);
-                var resolvedType = ResolveTypeName(translated.PrimitiveType, context);
+                var resolvedType = TypeResolverHelper.ResolveTypeName(translated.PrimitiveType, context);
                 var generatedFieldName = TypeTranslator.NormalizeName(field.Name);
 
                 if (isOptional)
@@ -228,7 +234,7 @@ namespace SbeSourceGenerator.Generators
                         effectivePrimitiveType,
                         field.Description,
                         ParseOffset(field.Offset, field.Name, sourceContext),
-                        GetTypeLength(field.Type, context),
+                        TypeResolverHelper.GetTypeLength(field.Type, context),
                         field.SinceVersion,
                         field.Deprecated,
                         field.NullValue == "" ? null : field.NullValue,
@@ -245,7 +251,7 @@ namespace SbeSourceGenerator.Generators
                         resolvedType,
                         field.Description,
                         ParseOffset(field.Offset, field.Name, sourceContext),
-                        GetTypeLength(field.Type, context),
+                        TypeResolverHelper.GetTypeLength(field.Type, context),
                         field.SinceVersion,
                         field.Deprecated,
                         context.EndianConversion,
@@ -264,9 +270,9 @@ namespace SbeSourceGenerator.Generators
                 result.Add(new ConstantMessageFieldDefinition(
                     TypeTranslator.NormalizeName(constant.Name),
                     constant.Id,
-                    ResolveTypeName(TypeTranslator.Translate(constant.Type).PrimitiveType, context),
+                    TypeResolverHelper.ResolveTypeName(TypeTranslator.Translate(constant.Type).PrimitiveType, context),
                     constant.Description != "" ? constant.Description : constant.Type,
-                    NormalizeValueRef(constant.ValueRef, context)
+                    TypeResolverHelper.NormalizeValueRef(constant.ValueRef, context)
                 ));
             }
             return result;
@@ -281,13 +287,13 @@ namespace SbeSourceGenerator.Generators
             var result = new List<IFileContentGenerator>(groups.Count);
             foreach (var group in groups)
             {
-                var groupName = RegisterGeneratedTypeName(context, group.Name);
+                var groupName = TypeResolverHelper.RegisterGeneratedTypeName(context, group.Name, sourceContext);
 
                 var groupFields = new List<IFileContentGenerator>(group.Fields.Count);
                 foreach (var field in group.Fields)
                 {
                     var translatedField = TypeTranslator.Translate(field.Type);
-                    var resolvedFieldType = ResolveTypeName(translatedField.PrimitiveType, context);
+                    var resolvedFieldType = TypeResolverHelper.ResolveTypeName(translatedField.PrimitiveType, context);
                     var generatedFieldName = TypeTranslator.NormalizeName(field.Name);
                     var underlyingFieldType = GetUnderlyingType(field.Type, context);
                     groupFields.Add(new MessageFieldDefinition(
@@ -296,7 +302,7 @@ namespace SbeSourceGenerator.Generators
                         resolvedFieldType,
                         field.Description,
                         ParseOffset(field.Offset, field.Name, sourceContext),
-                        GetTypeLength(field.Type, context),
+                        TypeResolverHelper.GetTypeLength(field.Type, context),
                         field.SinceVersion,
                         field.Deprecated,
                         context.EndianConversion,
@@ -305,13 +311,13 @@ namespace SbeSourceGenerator.Generators
                 }
 
                 var groupConstants = BuildConstants(group.Constants, context);
-                var numInGroupType = ResolveTypeName(GetNumInGroupType(group.DimensionType, context, sourceContext), context);
+                var numInGroupType = TypeResolverHelper.ResolveTypeName(GetNumInGroupType(group.DimensionType, context, sourceContext), context);
 
                 result.Add(new GroupDefinition(
                     versionNamespace,
                     groupName,
                     group.Id,
-                    ResolveTypeName(group.DimensionType, context),
+                    TypeResolverHelper.ResolveTypeName(group.DimensionType, context),
                     group.Description,
                     groupFields,
                     groupConstants,
@@ -347,7 +353,7 @@ namespace SbeSourceGenerator.Generators
                 result.Add(new DataFieldDefinition(
                     TypeTranslator.NormalizeName(data.Name),
                     data.Id,
-                    ResolveTypeName(data.Type, context),
+                    TypeResolverHelper.ResolveTypeName(data.Type, context),
                     data.Description,
                     lengthPrefixType
                 ));
@@ -368,26 +374,6 @@ namespace SbeSourceGenerator.Generators
             return null;
         }
 
-        private static int GetTypeLength(string type, SchemaContext context, SourceProductionContext sourceContext = default, string elementName = "")
-        {
-            int length;
-            var translated = TypeTranslator.Translate(type).PrimitiveType;
-            if (!TypesCatalog.PrimitiveTypeLengths.TryGetValue(translated, out length)
-                && !context.CustomTypeLengths.TryGetValue(type, out length))
-            {
-                if (sourceContext.CancellationToken != default)
-                {
-                    sourceContext.ReportDiagnostic(Diagnostic.Create(
-                        SbeDiagnostics.UnresolvedTypeReference,
-                        Location.None,
-                        type,
-                        elementName));
-                }
-                return 0;
-            }
-            return length;
-        }
-
         private static string GetNumInGroupType(string dimensionType, SchemaContext context, SourceProductionContext sourceContext = default)
         {
             var key = $"{dimensionType}.numInGroup";
@@ -405,60 +391,6 @@ namespace SbeSourceGenerator.Generators
                     $"Composite type '{dimensionType}' not found. Falling back to ushort for numInGroup."));
             }
             return "ushort";
-        }
-
-        private static string RegisterGeneratedTypeName(SchemaContext context, string originalName)
-        {
-            if (string.IsNullOrEmpty(originalName))
-                return originalName;
-
-            var normalized = TypeTranslator.NormalizeName(originalName);
-            context.GeneratedTypeNames[originalName] = normalized;
-            return normalized;
-        }
-
-        private static string ResolveTypeName(string typeName, SchemaContext context)
-        {
-            if (string.IsNullOrEmpty(typeName))
-                return typeName;
-
-            if (IsDotNetPrimitive(typeName))
-                return typeName;
-
-            if (context.GeneratedTypeNames.TryGetValue(typeName, out var generated))
-                return generated;
-
-            return TypeTranslator.NormalizeName(typeName);
-        }
-
-        private static bool IsDotNetPrimitive(string typeName) => DotNetPrimitiveTypes.Contains(typeName);
-
-        private static string NormalizeValueRef(string valueRef, SchemaContext context)
-        {
-            if (string.IsNullOrWhiteSpace(valueRef))
-                return valueRef;
-
-            int separatorIndex = valueRef.IndexOf('.');
-            string separator = ".";
-
-            if (separatorIndex < 0)
-            {
-                separatorIndex = valueRef.IndexOf("::", StringComparison.Ordinal);
-                if (separatorIndex >= 0)
-                    separator = "::";
-            }
-
-            if (separatorIndex < 0)
-                return ResolveTypeName(valueRef, context);
-
-            var typePart = valueRef.Substring(0, separatorIndex);
-            var remainder = valueRef.Substring(separatorIndex + separator.Length);
-            var normalizedType = ResolveTypeName(typePart, context);
-
-            if (remainder.Length == 0)
-                return normalizedType;
-
-            return string.Concat(normalizedType, separator, remainder);
         }
 
         private static int? ParseOffset(string offset, string fieldName, SourceProductionContext sourceContext)

--- a/src/SbeCodeGenerator/Generators/TypeResolverHelper.cs
+++ b/src/SbeCodeGenerator/Generators/TypeResolverHelper.cs
@@ -1,0 +1,120 @@
+using Microsoft.CodeAnalysis;
+using SbeSourceGenerator.Diagnostics;
+using System;
+using System.Collections.Generic;
+
+namespace SbeSourceGenerator.Generators
+{
+    /// <summary>
+    /// Shared helpers for resolving SBE type names, value references,
+    /// and type lengths across code generators.
+    /// </summary>
+    internal static class TypeResolverHelper
+    {
+        private static readonly HashSet<string> DotNetPrimitiveTypes = new(StringComparer.Ordinal)
+        {
+            "bool",
+            "byte",
+            "sbyte",
+            "short",
+            "ushort",
+            "int",
+            "uint",
+            "long",
+            "ulong",
+            "float",
+            "double",
+            "char",
+            "string"
+        };
+
+        public static bool IsDotNetPrimitive(string typeName) => DotNetPrimitiveTypes.Contains(typeName);
+
+        public static string ResolveTypeName(string typeName, SchemaContext context)
+        {
+            if (string.IsNullOrEmpty(typeName))
+                return typeName;
+
+            if (IsDotNetPrimitive(typeName))
+                return typeName;
+
+            if (context.GeneratedTypeNames.TryGetValue(typeName, out var generated))
+                return generated;
+
+            return TypeTranslator.NormalizeName(typeName);
+        }
+
+        public static string NormalizeValueRef(string valueRef, SchemaContext context)
+        {
+            if (string.IsNullOrWhiteSpace(valueRef))
+                return valueRef;
+
+            int separatorIndex = valueRef.IndexOf('.');
+            string separator = ".";
+
+            if (separatorIndex < 0)
+            {
+                separatorIndex = valueRef.IndexOf("::", StringComparison.Ordinal);
+                if (separatorIndex >= 0)
+                    separator = "::";
+            }
+
+            if (separatorIndex < 0)
+                return ResolveTypeName(valueRef, context);
+
+            var typePart = valueRef.Substring(0, separatorIndex);
+            var remainder = valueRef.Substring(separatorIndex + separator.Length);
+            var normalizedType = ResolveTypeName(typePart, context);
+
+            if (remainder.Length == 0)
+                return normalizedType;
+
+            return string.Concat(normalizedType, separator, remainder);
+        }
+
+        public static int GetTypeLength(string type, SchemaContext context, SourceProductionContext sourceContext = default, string elementName = "")
+        {
+            if (TypesCatalog.PrimitiveTypeLengths.TryGetValue(type, out int length))
+                return length;
+
+            if (context.CustomTypeLengths.TryGetValue(type, out length))
+                return length;
+
+            var translated = TypeTranslator.Translate(type).PrimitiveType;
+            if (TypesCatalog.PrimitiveTypeLengths.TryGetValue(translated, out length))
+                return length;
+
+            if (sourceContext.CancellationToken != default)
+            {
+                sourceContext.ReportDiagnostic(Diagnostic.Create(
+                    SbeDiagnostics.UnresolvedTypeReference,
+                    Location.None,
+                    type,
+                    elementName));
+            }
+            return 0;
+        }
+
+        public static string RegisterGeneratedTypeName(SchemaContext context, string originalName, SourceProductionContext sourceContext = default)
+        {
+            if (string.IsNullOrEmpty(originalName))
+                return originalName;
+
+            var normalized = TypeTranslator.NormalizeName(originalName);
+
+            if (context.GeneratedTypeNames.ContainsKey(originalName))
+            {
+                if (sourceContext.CancellationToken != default)
+                {
+                    sourceContext.ReportDiagnostic(Diagnostic.Create(
+                        SbeDiagnostics.DuplicateTypeName,
+                        Location.None,
+                        originalName));
+                }
+            }
+
+            context.GeneratedTypeNames[originalName] = normalized;
+            return normalized;
+        }
+    }
+}

--- a/src/SbeCodeGenerator/Generators/Types/CompositeDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Types/CompositeDefinition.cs
@@ -72,24 +72,22 @@ namespace SbeSourceGenerator
 
             if (!blittable)
             {
-                string varDataType = Fields.Where(f => f is ArrayFieldDefinition)
-                    .Select(f => ((ArrayFieldDefinition)f).PrimitiveType)
-                    .First();
+                var valueField = Fields.OfType<ValueFieldDefinition>().FirstOrDefault();
+                var arrayField = Fields.OfType<ArrayFieldDefinition>().FirstOrDefault();
 
-                // Generate constructor for readonly ref struct
-                var valueField = Fields.Where(f => f is ValueFieldDefinition).Cast<ValueFieldDefinition>().First();
-                var arrayField = Fields.Where(f => f is ArrayFieldDefinition).Cast<ArrayFieldDefinition>().First();
+                if (valueField != null && arrayField != null)
+                {
+                    sb.AppendSummary($"Initializes a new instance of {Name} with the specified values.", tabs, nameof(CompositeDefinition));
+                    sb.AppendTabs(tabs).Append("public ").Append(Name).Append("(").Append(valueField.PrimitiveType).Append(" ").Append(valueField.Name.FirstCharToLower()).Append(", ReadOnlySpan<").Append(arrayField.PrimitiveType).Append("> ").Append(arrayField.Name.FirstCharToLower()).AppendLine(")");
+                    sb.AppendLine("{", tabs++);
+                    sb.AppendTabs(tabs).Append(valueField.Name).Append(" = ").Append(valueField.Name.FirstCharToLower()).AppendLine(";");
+                    sb.AppendTabs(tabs).Append(arrayField.Name).Append(" = ").Append(arrayField.Name.FirstCharToLower()).AppendLine(";");
+                    sb.AppendLine("}", --tabs);
+                    sb.AppendLine("", tabs);
 
-                sb.AppendSummary($"Initializes a new instance of {Name} with the specified values.", tabs, nameof(CompositeDefinition));
-                sb.AppendTabs(tabs).Append("public ").Append(Name).Append("(").Append(valueField.PrimitiveType).Append(" ").Append(valueField.Name.FirstCharToLower()).Append(", ReadOnlySpan<").Append(arrayField.PrimitiveType).Append("> ").Append(arrayField.Name.FirstCharToLower()).AppendLine(")");
-                sb.AppendLine("{", tabs++);
-                sb.AppendTabs(tabs).Append(valueField.Name).Append(" = ").Append(valueField.Name.FirstCharToLower()).AppendLine(";");
-                sb.AppendTabs(tabs).Append(arrayField.Name).Append(" = ").Append(arrayField.Name.FirstCharToLower()).AppendLine(";");
-                sb.AppendLine("}", --tabs);
-                sb.AppendLine("", tabs);
-
-                sb.AppendSummary("Create instance from buffer", tabs, nameof(CompositeDefinition));
-                sb.AppendTabs(tabs).Append("public static ").Append(Name).Append(" Create(ReadOnlySpan<byte> buffer) => new ").Append(Name).AppendLine("(MemoryMarshal.AsRef<byte>(buffer), buffer.Slice(1));");
+                    sb.AppendSummary("Create instance from buffer", tabs, nameof(CompositeDefinition));
+                    sb.AppendTabs(tabs).Append("public static ").Append(Name).Append(" Create(ReadOnlySpan<byte> buffer) => new ").Append(Name).AppendLine("(MemoryMarshal.AsRef<byte>(buffer), buffer.Slice(1));");
+                }
 
                 sb.AppendSummary("Callback delegate used on ConsumeVariableLengthSegments", tabs, nameof(CompositeDefinition));
                 sb.AppendTabs(tabs).Append("public delegate void Callback(").Append(Name).AppendLine(" data);");

--- a/src/SbeCodeGenerator/Generators/Types/GroupDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Types/GroupDefinition.cs
@@ -78,10 +78,16 @@ namespace SbeSourceGenerator
             int offset = 0;
             foreach (var field in Fields)
             {
-                var blittableField = (IBlittableMessageField)field;
-                blittableField.Offset ??= offset;
-                field.AppendFileContent(sb, tabs);
-                offset = blittableField.Offset.Value + blittableField.Length;
+                if (field is IBlittableMessageField blittableField)
+                {
+                    blittableField.Offset ??= offset;
+                    field.AppendFileContent(sb, tabs);
+                    offset = blittableField.Offset.Value + blittableField.Length;
+                }
+                else
+                {
+                    field.AppendFileContent(sb, tabs);
+                }
             }
         }
     }

--- a/src/SbeCodeGenerator/Generators/TypesCodeGenerator.cs
+++ b/src/SbeCodeGenerator/Generators/TypesCodeGenerator.cs
@@ -2,7 +2,6 @@ using Microsoft.CodeAnalysis;
 using SbeSourceGenerator.Diagnostics;
 using SbeSourceGenerator.Helpers;
 using SbeSourceGenerator.Schema;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -14,23 +13,6 @@ namespace SbeSourceGenerator.Generators
     /// </summary>
     internal class TypesCodeGenerator : ICodeGenerator
     {
-        private static readonly HashSet<string> DotNetPrimitiveTypes = new(StringComparer.Ordinal)
-        {
-            "bool",
-            "byte",
-            "sbyte",
-            "short",
-            "ushort",
-            "int",
-            "uint",
-            "long",
-            "ulong",
-            "float",
-            "double",
-            "char",
-            "string"
-        };
-
         public IEnumerable<(string name, string content)> Generate(string ns, ParsedSchema schema, SchemaContext context, SourceProductionContext sourceContext)
         {
             foreach (var compositeDto in schema.Composites)
@@ -57,7 +39,7 @@ namespace SbeSourceGenerator.Generators
 
         private static IEnumerable<(string name, string content)> GenerateSet(string ns, SchemaEnumDto enumDto, SchemaContext context, SourceProductionContext sourceContext)
         {
-            var generatedName = RegisterGeneratedTypeName(context, enumDto.Name);
+            var generatedName = TypeResolverHelper.RegisterGeneratedTypeName(context, enumDto.Name, sourceContext);
             var encodingTranslated = TypeTranslator.Translate(enumDto.EncodingType);
             int maxBitPosition = TypesCatalog.GetPrimitiveLength(encodingTranslated.PrimitiveType) * 8 - 1;
 
@@ -100,7 +82,7 @@ namespace SbeSourceGenerator.Generators
                 generatedName,
                 enumDto.Description,
                 encodingTranslated.PrimitiveType,
-                GetTypeLength(encodingTranslated.PrimitiveType, context),
+                TypeResolverHelper.GetTypeLength(encodingTranslated.PrimitiveType, context),
                 validChoices
             );
             if (generator is IBlittable blittableType)
@@ -116,7 +98,7 @@ namespace SbeSourceGenerator.Generators
 
             if (!TypeTranslator.IsPrimitive(typeDto.Name))
             {
-                var generatedName = RegisterGeneratedTypeName(context, typeDto.Name);
+                var generatedName = TypeResolverHelper.RegisterGeneratedTypeName(context, typeDto.Name, sourceContext);
                 int lengthValue = 0;
                 if (!string.IsNullOrEmpty(typeDto.Length))
                 {
@@ -141,7 +123,7 @@ namespace SbeSourceGenerator.Generators
                         ns,
                         generatedName,
                         typeDto.Description,
-                        ResolveTypeName(nativeType, context),
+                        TypeResolverHelper.ResolveTypeName(nativeType, context),
                         typeDto.SemanticType,
                         typeDto.Length,
                         typeDto.InnerText
@@ -157,18 +139,18 @@ namespace SbeSourceGenerator.Generators
                         ns,
                         generatedName,
                         typeDto.Description,
-                        ResolveTypeName(nativeType, context),
+                        TypeResolverHelper.ResolveTypeName(nativeType, context),
                         typeDto.SemanticType,
                         typeDto.NullValue,
-                        GetTypeLength(nativeType, context)
+                        TypeResolverHelper.GetTypeLength(nativeType, context)
                     ),
                     _ => new TypeDefinition(
                         ns,
                         generatedName,
                         typeDto.Description,
-                        ResolveTypeName(nativeType, context),
+                        TypeResolverHelper.ResolveTypeName(nativeType, context),
                         typeDto.SemanticType,
-                        GetTypeLength(nativeType, context)
+                        TypeResolverHelper.GetTypeLength(nativeType, context)
                     )
                 };
                 if (generator is ConstantTypeDefinition)
@@ -176,7 +158,7 @@ namespace SbeSourceGenerator.Generators
                 if (generator is OptionalTypeDefinition)
                 {
                     context.OptionalTypes[typeDto.Name] = nativeType;
-                    var resolvedType = ResolveTypeName(nativeType, context);
+                    var resolvedType = TypeResolverHelper.ResolveTypeName(nativeType, context);
                     if (string.IsNullOrEmpty(typeDto.NullValue) && !TypesCatalog.HasNullValue(resolvedType)
                         && sourceContext.CancellationToken != default)
                     {
@@ -197,7 +179,7 @@ namespace SbeSourceGenerator.Generators
 
         private static IEnumerable<(string name, string content)> GenerateEnum(string ns, SchemaEnumDto enumDto, SchemaContext context, SourceProductionContext sourceContext)
         {
-            var generatedName = RegisterGeneratedTypeName(context, enumDto.Name);
+            var generatedName = TypeResolverHelper.RegisterGeneratedTypeName(context, enumDto.Name, sourceContext);
             var encodingTranslated = TypeTranslator.Translate(enumDto.EncodingType);
 
             if (!TypesCatalog.HasPrimitiveLength(encodingTranslated.PrimitiveType) && sourceContext.CancellationToken != default)
@@ -276,7 +258,7 @@ namespace SbeSourceGenerator.Generators
                 }
             }
 
-            var generatedName = RegisterGeneratedTypeName(context, compositeDto.Name);
+            var generatedName = TypeResolverHelper.RegisterGeneratedTypeName(context, compositeDto.Name, sourceContext);
 
             // Separate ref fields from primitive fields
             var refFields = compositeDto.Fields
@@ -293,11 +275,11 @@ namespace SbeSourceGenerator.Generators
 
             foreach (var ft in fieldTranslations)
             {
-                context.CompositeFieldTypes[$"{compositeDto.Name}.{ft.Field.Name}"] = ResolveTypeName(ft.Translation.PrimitiveType, context);
+                context.CompositeFieldTypes[$"{compositeDto.Name}.{ft.Field.Name}"] = TypeResolverHelper.ResolveTypeName(ft.Translation.PrimitiveType, context);
 
                 if (ft.Field.Presence == "optional" && string.IsNullOrEmpty(ft.Field.NullValue))
                 {
-                    var resolvedType = ResolveTypeName(ft.Translation.PrimitiveType, context);
+                    var resolvedType = TypeResolverHelper.ResolveTypeName(ft.Translation.PrimitiveType, context);
                     if (!TypesCatalog.HasNullValue(resolvedType) && sourceContext.CancellationToken != default)
                     {
                         sourceContext.ReportDiagnostic(Diagnostic.Create(
@@ -311,7 +293,7 @@ namespace SbeSourceGenerator.Generators
             // Register ref fields in CompositeFieldTypes
             foreach (var rf in refFields)
             {
-                var resolvedRefType = ResolveTypeName(rf.Type, context);
+                var resolvedRefType = TypeResolverHelper.ResolveTypeName(rf.Type, context);
                 context.CompositeFieldTypes[$"{compositeDto.Name}.{rf.Name}"] = resolvedRefType;
             }
 
@@ -327,15 +309,15 @@ namespace SbeSourceGenerator.Generators
                         ("constant", _) => new ConstantTypeFieldDefinition(
                             TypeTranslator.NormalizeName(ft.Field.Name),
                             ft.Field.Description,
-                            ResolveTypeName(ft.Translation.PrimitiveType, context),
+                            TypeResolverHelper.ResolveTypeName(ft.Translation.PrimitiveType, context),
                             InsertQuotationsIfNeeded(ft.Field.InnerText, ft.Field.PrimitiveType, ft.Field.Length),
-                            NormalizeValueRef(ft.Field.ValueRef, context)
+                            TypeResolverHelper.NormalizeValueRef(ft.Field.ValueRef, context)
                         ),
                         ("optional", _) => new NullableValueFieldDefinition(
                             TypeTranslator.NormalizeName(ft.Field.Name),
                             ft.Field.Description,
-                            ResolveTypeName(ft.Translation.PrimitiveType, context),
-                            GetTypeLength(ft.Translation.PrimitiveType, context),
+                            TypeResolverHelper.ResolveTypeName(ft.Translation.PrimitiveType, context),
+                            TypeResolverHelper.GetTypeLength(ft.Translation.PrimitiveType, context),
                             ft.Field.NullValue == "" ? null : ft.Field.NullValue,
                             context.EndianConversion
                         ),
@@ -347,15 +329,15 @@ namespace SbeSourceGenerator.Generators
                         _ => (IFileContentGenerator)new ValueFieldDefinition(
                             TypeTranslator.NormalizeName(ft.Field.Name),
                             ft.Field.Description,
-                            ResolveTypeName(ft.Translation.PrimitiveType, context),
-                            GetTypeLength(ft.Translation.PrimitiveType, context),
+                            TypeResolverHelper.ResolveTypeName(ft.Translation.PrimitiveType, context),
+                            TypeResolverHelper.GetTypeLength(ft.Translation.PrimitiveType, context),
                             context.EndianConversion
                         )
                     });
                 }
                 else if (!string.IsNullOrEmpty(field.Type))
                 {
-                    var resolvedRefType = ResolveTypeName(field.Type, context);
+                    var resolvedRefType = TypeResolverHelper.ResolveTypeName(field.Type, context);
                     var refLength = context.CustomTypeLengths.TryGetValue(field.Type, out var len) ? len : 0;
                     fields.Add(new CompositeRefFieldDefinition(
                         TypeTranslator.NormalizeName(field.Name),
@@ -391,80 +373,5 @@ namespace SbeSourceGenerator.Generators
             };
         }
 
-        private static int GetTypeLength(string type, SchemaContext context, SourceProductionContext sourceContext = default, string elementName = "")
-        {
-            int length;
-            if (!TypesCatalog.PrimitiveTypeLengths.TryGetValue(type, out length)
-                && !context.CustomTypeLengths.TryGetValue(type, out length)
-                && !TypesCatalog.PrimitiveTypeLengths.TryGetValue(TypeTranslator.Translate(type).PrimitiveType, out length))
-            {
-                if (sourceContext.CancellationToken != default)
-                {
-                    sourceContext.ReportDiagnostic(Diagnostic.Create(
-                        SbeDiagnostics.UnresolvedTypeReference,
-                        Location.None,
-                        type,
-                        elementName));
-                }
-                return 0;
-            }
-            return length;
-        }
-
-        private static string RegisterGeneratedTypeName(SchemaContext context, string originalName)
-        {
-            if (string.IsNullOrEmpty(originalName))
-                return originalName;
-
-            var normalized = TypeTranslator.NormalizeName(originalName);
-            context.GeneratedTypeNames[originalName] = normalized;
-            return normalized;
-        }
-
-        private static string ResolveTypeName(string typeName, SchemaContext context)
-        {
-            if (string.IsNullOrEmpty(typeName))
-                return typeName;
-
-            if (IsDotNetPrimitive(typeName))
-                return typeName;
-
-            if (context.GeneratedTypeNames.TryGetValue(typeName, out var generated))
-                return generated;
-
-            return TypeTranslator.NormalizeName(typeName);
-        }
-
-        private static bool IsDotNetPrimitive(string typeName) => DotNetPrimitiveTypes.Contains(typeName);
-
-        private static string NormalizeValueRef(string valueRef, SchemaContext context)
-        {
-            if (string.IsNullOrWhiteSpace(valueRef))
-                return valueRef;
-
-            int separatorIndex = valueRef.IndexOf('.');
-            string separator = ".";
-
-            if (separatorIndex < 0)
-            {
-                separatorIndex = valueRef.IndexOf("::", StringComparison.Ordinal);
-                if (separatorIndex >= 0)
-                {
-                    separator = "::";
-                }
-            }
-
-            if (separatorIndex < 0)
-                return ResolveTypeName(valueRef, context);
-
-            var typePart = valueRef.Substring(0, separatorIndex);
-            var remainder = valueRef.Substring(separatorIndex + separator.Length);
-            var normalizedType = ResolveTypeName(typePart, context);
-
-            if (remainder.Length == 0)
-                return normalizedType;
-
-            return string.Concat(normalizedType, separator, remainder);
-        }
     }
 }

--- a/tests/SbeCodeGenerator.Tests/DiagnosticsTests.cs
+++ b/tests/SbeCodeGenerator.Tests/DiagnosticsTests.cs
@@ -126,6 +126,79 @@ namespace SbeCodeGenerator.Tests
             // Verify SBE006 - Invalid type length
             Assert.Equal("SBE006", SbeDiagnostics.InvalidTypeLength.Id);
             Assert.Equal(DiagnosticSeverity.Error, SbeDiagnostics.InvalidTypeLength.DefaultSeverity);
+
+            // Verify SBE013 - Duplicate type name
+            Assert.Equal("SBE013", SbeDiagnostics.DuplicateTypeName.Id);
+            Assert.Equal(DiagnosticSeverity.Warning, SbeDiagnostics.DuplicateTypeName.DefaultSeverity);
+
+            // Verify SBE014 - sinceVersion exceeds schema version
+            Assert.Equal("SBE014", SbeDiagnostics.SinceVersionExceedsSchemaVersion.Id);
+            Assert.Equal(DiagnosticSeverity.Warning, SbeDiagnostics.SinceVersionExceedsSchemaVersion.DefaultSeverity);
+        }
+
+        [Fact]
+        public void Generate_WithDuplicateTypeName_CompletesSuccessfully()
+        {
+            var generator = new TypesCodeGenerator();
+            var context = new SchemaContext("test-schema");
+            var schema = SchemaReader.Parse(@"
+                <messageSchema>
+                    <types>
+                        <enum name='Side' encodingType='uint8'>
+                            <validValue name='Buy'>1</validValue>
+                        </enum>
+                        <enum name='Side' encodingType='uint8'>
+                            <validValue name='Sell'>2</validValue>
+                        </enum>
+                    </types>
+                </messageSchema>");
+
+            // Should not throw — last definition wins
+            var results = generator.Generate("TestNamespace", schema, context, default(SourceProductionContext)).ToList();
+            Assert.NotEmpty(results);
+            // The last definition should be the one that's generated
+            var sideResult = results.Last(r => r.name.Contains("Side"));
+            Assert.Contains("Sell", sideResult.content);
+        }
+
+        [Fact]
+        public void Generate_WithSinceVersionExceedingSchemaVersion_CompletesSuccessfully()
+        {
+            var generator = new MessagesCodeGenerator();
+            var context = new SchemaContext("test-schema");
+            var schema = SchemaReader.Parse(@"
+                <messageSchema version='1'>
+                    <types>
+                        <composite name='messageHeader' description='Message header'>
+                            <type name='blockLength' primitiveType='uint16'/>
+                            <type name='templateId' primitiveType='uint16'/>
+                            <type name='schemaId' primitiveType='uint16'/>
+                            <type name='version' primitiveType='uint16'/>
+                        </composite>
+                    </types>
+                    <message name='TestMsg' id='1'>
+                        <field name='price' id='1' type='uint64'/>
+                        <field name='quantity' id='2' type='uint32' sinceVersion='5'/>
+                    </message>
+                </messageSchema>");
+
+            // Should not throw even with sinceVersion=5 > schemaVersion=1
+            var results = generator.Generate("TestNamespace", schema, context, default(SourceProductionContext)).ToList();
+            Assert.NotEmpty(results);
+        }
+
+        [Fact]
+        public void TypeResolverHelper_RegisterGeneratedTypeName_DetectsDuplicates()
+        {
+            var context = new SchemaContext("test-schema");
+
+            // First registration succeeds
+            TypeResolverHelper.RegisterGeneratedTypeName(context, "MyType");
+            Assert.True(context.GeneratedTypeNames.ContainsKey("MyType"));
+
+            // Second registration with same name overwrites (but would emit diagnostic with real sourceContext)
+            TypeResolverHelper.RegisterGeneratedTypeName(context, "MyType");
+            Assert.True(context.GeneratedTypeNames.ContainsKey("MyType"));
         }
     }
 }

--- a/tests/SbeCodeGenerator.Tests/TypesCodeGeneratorTests.cs
+++ b/tests/SbeCodeGenerator.Tests/TypesCodeGeneratorTests.cs
@@ -835,5 +835,30 @@ namespace SbeCodeGenerator.Tests
             Assert.Contains(results, r => r.name.Contains("Side"));
             Assert.Contains(results, r => r.name.Contains("Decimal"));
         }
+
+        [Fact]
+        public void Generate_WithDuplicateEnumName_LastDefinitionWins()
+        {
+            var generator = new TypesCodeGenerator();
+            var context = new SchemaContext("test-schema");
+            var schema = SchemaReader.Parse(@"
+                <messageSchema>
+                    <types>
+                        <enum name='Side' encodingType='uint8'>
+                            <validValue name='Buy'>1</validValue>
+                        </enum>
+                        <enum name='Side' encodingType='uint8'>
+                            <validValue name='Sell'>2</validValue>
+                        </enum>
+                    </types>
+                </messageSchema>");
+
+            var results = generator.Generate("TestNamespace", schema, context, default(SourceProductionContext)).ToList();
+            // Both should generate (duplicate detection is a warning, not an error)
+            var sideResults = results.Where(r => r.name.Contains("Side")).ToList();
+            Assert.Equal(2, sideResults.Count);
+            // Last definition includes Sell
+            Assert.Contains("Sell", sideResults.Last().content);
+        }
     }
 }


### PR DESCRIPTION
## Changes

### Code Quality
- **Extract TypeResolverHelper** — Deduplicated `ResolveTypeName`, `NormalizeValueRef`, `GetTypeLength`, `RegisterGeneratedTypeName`, and `DotNetPrimitiveTypes` from `MessagesCodeGenerator` and `TypesCodeGenerator` into shared `TypeResolverHelper` class (~100 lines removed)
- **Unified GetTypeLength** — Now uses 3-step lookup (raw → custom → translated) consistently, fixing a subtle difference between the two previous implementations

### Bug Fixes
- **CompositeDefinition .First() crash** — Non-blittable composites missing expected field types (ArrayFieldDefinition/ValueFieldDefinition) would throw `InvalidOperationException`. Now uses `FirstOrDefault()` with null guard.
- **GroupDefinition unchecked cast** — Direct cast to `IBlittableMessageField` could throw `InvalidCastException`. Now uses safe `is` pattern match.

### New Diagnostics
- **SBE013** — Warning when duplicate type names are defined in a schema
- **SBE014** — Warning when `sinceVersion` exceeds the schema `version` attribute

### Tests
- 166 unit tests ✅ (+4 new)
- 72 integration tests ✅ (2 pre-existing VersioningIntegrationTests failures)