### PR TITLE
fix: char array composites, naming normalization, edge case tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-04-10
+
+### Added
+- **Zero-copy decode with `ReadBlockRef<T>`**: New `SpanReader.ReadBlockRef<T>(int blockLength)` returns `ref readonly T` directly into the buffer, avoiding any struct copies. Uses `Unsafe.NullRef<T>()` sentinel for failure — callers check with `Unsafe.IsNullRef`.
+- **`TryReadBlock<T>` with schema backward compatibility**: New `SpanReader.TryReadBlock<T>(int blockLength, out T value)` replaces `TryReadGroupEntry`. When `blockLength < sizeof(T)`, performs partial read with zero-padded trailing fields (schema evolution backward compat). When `blockLength > sizeof(T)`, reads the struct and skips extra bytes (forward compat).
+- **`in` delegate callbacks for group consume** (**Breaking**): Group callbacks changed from `Action<GroupData>` to custom `{GroupName}Handler(in GroupData data)` delegates. This eliminates struct copies when passing group entries to callbacks. Nested groups include parent context: `AccelerationHandler(in PerformanceFiguresData parent, in AccelerationData data)`.
+- **Cross-schema reference validation**: Integration tests confirming multiple SBE schemas coexist in the same project with isolated namespaces, no type conflicts, and independent encode/decode.
+
+### Changed
+- **Simplified TryParse/TryParseWithReader**: Replaced ~30 lines of manual sizeof/skip/evolution logic with single `TryReadBlock<T>(blockLength, out message)` call. TryReadBlock handles all schema evolution cases internally.
+- Generated messages now include `using System.Runtime.InteropServices` for `MemoryMarshal` access.
+
+### Fixed
+- **Zero-field group consume**: Groups with `blockLength=0` (no fields) now decode correctly. Previously, `TryRead<T>` advanced by `Unsafe.SizeOf<T>()` (always ≥1 for empty structs) instead of the wire `blockLength`.
+- **Char array composites**: Fixed char array field generation in composites to use correct `InlineArray` attribute.
+- **Set/enum naming normalization**: Consistent PascalCase naming for generated set and enum types.
+- **Generation order**: Types are now generated before messages, ensuring `SchemaContext` type registrations are available during message generation.
+
 ## [0.8.0] - 2026-04-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Zero-field group consume**: Groups with `blockLength=0` (no fields) now decode correctly. Previously, `TryRead<T>` advanced by `Unsafe.SizeOf<T>()` (always ≥1 for empty structs) instead of the wire `blockLength`.
+- **Deeply nested group struct generation**: Groups nested 3+ levels deep now correctly generate their data structs. Previously only 1 level of nesting was handled, causing missing types (e.g., Binance ExchangeInfoResponse Permissions).
+- **Nested group variable shadowing**: Nested group consume code now uses unique variable names per depth level (`nestedData1`, `nestedData2`) to avoid C# variable shadowing.
 - **Char array composites**: Fixed char array field generation in composites to use correct `InlineArray` attribute.
 - **Set/enum naming normalization**: Consistent PascalCase naming for generated set and enum types.
 - **Generation order**: Types are now generated before messages, ensuring `SchemaContext` type registrations are available during message generation.

--- a/README.md
+++ b/README.md
@@ -13,12 +13,14 @@ A Roslyn-based source generator that converts FIX Simple Binary Encoding (SBE) X
 - Optional fields with null value semantics
 - Composite types (nested composites, `<ref>` elements)
 - Enumerations and bit sets (flag enums)
-- Repeating groups with nested groups (unlimited depth, ancestor context callbacks)
+- Repeating groups with nested groups (unlimited depth, ancestor context callbacks with `in`)
 - Variable-length data (varData) with configurable length prefix (uint8/uint16/uint32)
 - Constant fields in messages, composites, and groups
 - Automatic and explicit field offset calculation
-- Byte order handling (little-endian native, big-endian with property-based conversion)
+- Byte order handling (little-endian native, big-endian with `readonly` property-based conversion)
 - Schema versioning (`sinceVersion`, `deprecated` on fields, enums, sets, data)
+- Schema evolution forward/backward compatibility via `TryReadBlock<T>`
+- Cross-schema coexistence (multiple schemas with isolated namespaces)
 - Custom `headerType` support
 - `characterEncoding` attribute (UTF-8, Latin1)
 - Explicit `blockLength` on messages
@@ -39,7 +41,7 @@ Or add it directly to your `.csproj`:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="SbeSourceGenerator" Version="0.7.0" />
+  <PackageReference Include="SbeSourceGenerator" Version="0.9.0" />
 </ItemGroup>
 ```
 
@@ -120,8 +122,8 @@ bool success = OrderBookData.TryEncode(
 OrderBookData.TryParse(buffer, out var decoded, out var variableData);
 decoded.ConsumeVariableLengthSegments(
     variableData,
-    bid => Console.WriteLine($"Bid: {bid.Price}"),
-    ask => Console.WriteLine($"Ask: {ask.Price}")
+    (in BidsData bid) => Console.WriteLine($"Bid: {bid.Price}"),
+    (in AsksData ask) => Console.WriteLine($"Ask: {ask.Price}")
 );
 ```
 
@@ -328,7 +330,9 @@ The repository includes several example projects in the `examples/` folder:
 
 The generated code is designed for high performance:
 
-- Zero-copy deserialization where possible
+- Zero-copy deserialization with `ReadBlockRef<T>` (ref readonly into buffer)
+- `in` delegate callbacks for group consume (no struct copies)
+- `readonly` property getters to prevent defensive copies
 - Struct-based value types (no heap allocations)
 - Explicit memory layout for cache efficiency
 - Blittable types for P/Invoke scenarios
@@ -375,4 +379,4 @@ For questions, issues, or feature requests:
 
 ---
 
-**Version**: 0.7.0 (see [Changelog](./CHANGELOG.md))
+**Version**: 0.9.0 (see [Changelog](./CHANGELOG.md))

--- a/docs/FLUENT_ENCODER_API.md
+++ b/docs/FLUENT_ENCODER_API.md
@@ -249,3 +249,27 @@ The fluent API has **zero performance overhead** compared to the traditional API
 - ⚙️ When sharing a single writer across multiple messages
 - ⚙️ When you need fine-grained control over the encoding process
 - ⚙️ Custom encoding logic that doesn't fit the fluent pattern
+
+## Breaking Changes (v0.9.0)
+
+### Group Callback Delegates
+
+Group callbacks in `ConsumeVariableLengthSegments` changed from `Action<T>` to custom delegate types with `in` parameters:
+
+```csharp
+// Before (v0.8.x):
+decoded.ConsumeVariableLengthSegments(
+    variableData,
+    bid => ProcessBid(bid),
+    ask => ProcessAsk(ask)
+);
+
+// After (v0.9.0):
+decoded.ConsumeVariableLengthSegments(
+    variableData,
+    (in BidsData bid) => ProcessBid(in bid),
+    (in AsksData ask) => ProcessAsk(in ask)
+);
+```
+
+This change eliminates struct copies on every callback invocation, which is significant for large message structs. The `in` keyword passes structs by readonly reference instead of by value.

--- a/docs/PERFORMANCE_TUNING_GUIDE.md
+++ b/docs/PERFORMANCE_TUNING_GUIDE.md
@@ -218,12 +218,12 @@ if (TradeData.TryParse(buffer, out var trade, out _))
 For large messages, process groups incrementally:
 
 ```csharp
-// ✅ Good: Process groups as they're consumed
+// ✅ Good: Process groups as they're consumed (v0.9.0 uses in delegates)
 MarketDataData.TryParse(buffer, out var data, out var variableData);
 data.ConsumeVariableLengthSegments(
     variableData,
-    bid => ProcessBid(bid),      // Process immediately
-    ask => ProcessAsk(ask)       // Process immediately
+    (in BidData bid) => ProcessBid(in bid),    // Zero-copy via in
+    (in AskData ask) => ProcessAsk(in ask)     // Zero-copy via in
 );
 
 // ❌ Bad: Collect all groups first
@@ -231,8 +231,8 @@ var bids = new List<BidData>(); // Heap allocations
 var asks = new List<AskData>();
 data.ConsumeVariableLengthSegments(
     variableData,
-    bid => bids.Add(bid),
-    ask => asks.Add(ask)
+    (in BidData bid) => bids.Add(bid),
+    (in AskData ask) => asks.Add(ask)
 );
 ProcessBids(bids);
 ProcessAsks(asks);
@@ -249,8 +249,8 @@ Process repeating groups without materializing collections:
 long totalVolume = 0;
 data.ConsumeVariableLengthSegments(
     variableData,
-    bid => totalVolume += bid.Quantity,
-    ask => totalVolume += ask.Quantity
+    (in BidData bid) => totalVolume += bid.Quantity,
+    (in AskData ask) => totalVolume += ask.Quantity
 );
 
 // ❌ Bad: Materialize groups
@@ -258,8 +258,8 @@ var allBids = new List<BidData>();
 var allAsks = new List<AskData>();
 data.ConsumeVariableLengthSegments(
     variableData,
-    bid => allBids.Add(bid),
-    ask => allAsks.Add(ask)
+    (in BidData bid) => allBids.Add(bid),
+    (in AskData ask) => allAsks.Add(ask)
 );
 long totalVolume = allBids.Sum(b => b.Quantity) + allAsks.Sum(a => a.Quantity);
 ```
@@ -397,23 +397,30 @@ ProcessSymbolBytes(symbolBytes);
 ### 4. Defensive Copying
 
 ```csharp
-// ❌ Bad: Readonly struct in causes defensive copy
-public readonly struct Trade
+// ❌ Bad: Non-readonly property accessed through in/ref causes defensive copy
+public struct Trade
 {
-    public void Process() { /* ... */ }
+    public long Price { get => _price; }
 }
 
 void ProcessTrade(in Trade trade)
 {
-    trade.Process(); // Defensive copy!
+    var p = trade.Price; // Defensive copy of entire struct!
 }
 
-// ✅ Good: Mark method readonly
-public readonly struct Trade
+// ✅ Good: readonly prevents defensive copy (v0.9.0 generated code)
+public struct Trade
 {
-    public readonly void Process() { /* ... */ }
+    public readonly long Price { get => _price; }
+}
+
+void ProcessTrade(in Trade trade)
+{
+    var p = trade.Price; // Direct field load — no copy
 }
 ```
+
+> **Note**: On .NET 9 RyuJIT, the JIT elides defensive copies for trivial getters even without `readonly`. However, `readonly` is enforced at compile time and protects against Mono, NativeAOT, and alternative JITs. All v0.9.0 generated properties are `readonly`.
 
 ### 5. Closure Allocations
 
@@ -474,4 +481,4 @@ Target metrics for well-optimized code:
 
 ---
 
-**Last Updated**: 2025-10-15
+**Last Updated**: 2025-10-16

--- a/docs/SCHEMA_VERSIONING.md
+++ b/docs/SCHEMA_VERSIONING.md
@@ -61,7 +61,7 @@ public long Quantity;
 
 ### TryParse Methods
 
-The generated `TryParse` method accepts a `blockLength` parameter for version-aware parsing:
+The generated `TryParse` method uses `TryReadBlock<T>` for version-aware parsing:
 
 ```csharp
 public static bool TryParse(ReadOnlySpan<byte> buffer, int blockLength, 
@@ -69,33 +69,21 @@ public static bool TryParse(ReadOnlySpan<byte> buffer, int blockLength,
 {
     var reader = new SpanReader(buffer);
     
-    // Read the message data
-    if (!reader.TryRead<OrderData>(out message))
+    // TryReadBlock advances by blockLength, not sizeof(T)
+    // - blockLength < sizeof: partial read, trailing fields zeroed (backward compat)
+    // - blockLength > sizeof: full read, skips extra bytes (forward compat)
+    if (!reader.TryReadBlock<OrderData>(blockLength, out message))
     {
         variableData = default;
         return false;
     }
     
-    // Handle schema evolution: skip additional bytes if blockLength > MESSAGE_SIZE
-    var additionalBytes = blockLength - MESSAGE_SIZE;
-    if (additionalBytes > 0)
-    {
-        if (!reader.TrySkip(additionalBytes))
-        {
-            variableData = default;
-            return false;
-        }
-        variableData = reader.Remaining;
-    }
-    else
-    {
-        // For backward compatibility: variable data starts at blockLength
-        variableData = buffer.Slice(blockLength);
-    }
-    
+    variableData = reader.Remaining;
     return true;
 }
 ```
+
+> **v0.9.0**: `TryReadBlock<T>` replaces the previous manual `TryRead<T>` + skip/slice logic. It handles all schema evolution cases in a single method call, including the edge case where `blockLength == 0`.
 
 ## Usage Examples
 
@@ -263,13 +251,13 @@ V1 Message on wire:
 │  blockLength=16  │  orderId, price  │
 └──────────────────┴──────────────────┘
 
-V3 Decoder processes:
+V3 Decoder processes (TryReadBlock):
 1. Reads header: blockLength = 16
-2. Reads 25-byte struct (MESSAGE_SIZE)
-   - Bytes 0-15: orderId and price (present)
-   - Bytes 16-24: quantity and side (zeros/undefined)
-3. Computes: additionalBytes = 16 - 25 = -9 (negative)
-4. Sets: variableData = buffer.Slice(16)
+2. TryReadBlock<OrderData>(blockLength=16):
+   - sizeof(OrderData) = 25 > blockLength = 16
+   - Partial read: copies 16 bytes, zero-pads remaining 9
+   - Advances reader by 16 bytes
+3. Result: orderId and price populated, quantity and side = 0
 ```
 
 ### Example: V3 Message Read by V1 Decoder
@@ -281,12 +269,14 @@ V3 Message on wire:
 │  blockLength=25  │  all fields      │
 └──────────────────┴──────────────────┘
 
-V1 Decoder processes:
+V1 Decoder processes (TryReadBlock):
 1. Reads header: blockLength = 25
-2. Reads 25-byte struct (MESSAGE_SIZE for V1 = 16, but buffer is large enough)
-3. Computes: additionalBytes = 25 - 16 = 9 (positive)
-4. Skips 9 bytes (quantity and side)
-5. Sets: variableData = remaining after skip
+2. TryReadBlock<OrderData>(blockLength=25):
+   - sizeof(OrderData) = 16 <= blockLength = 25
+   - Full read: reads 16 bytes for struct
+   - Skips remaining 9 bytes (25 - 16)
+   - Advances reader by 25 bytes
+3. Result: orderId and price populated, extra fields skipped
 ```
 
 ## Testing Schema Evolution

--- a/docs/SPAN_READER_INTEGRATION.md
+++ b/docs/SPAN_READER_INTEGRATION.md
@@ -49,14 +49,15 @@ public void ConsumeVariableLengthSegments(ReadOnlySpan<byte> buffer, ...)
     {
         for (int i = 0; i < groupBids.NumInGroup; i++)
         {
-            if (reader.TryRead<BidsData>(out var data))
-            {
-                callbackBids(data);
-            }
+            if (!reader.TryReadBlock<BidsData>(groupBids.BlockLength, out var data))
+                break;
+            callbackBids(in data);
         }
     }
 }
 ```
+
+> **v0.9.0 Changes**: Group entries are now read with `TryReadBlock<T>(blockLength, out T)` instead of `TryRead<T>`, which correctly advances by the wire `blockLength` rather than `sizeof(T)`. This fixes zero-field groups and enables schema forward/backward compatibility. Callbacks use `in` delegates to avoid struct copies.
 
 ### Implementation Details
 
@@ -73,9 +74,16 @@ public void ConsumeVariableLengthSegments(ReadOnlySpan<byte> buffer, ...)
 
 ### ✅ Schema Evolution
 The SpanReader integration maintains full support for schema evolution:
-- `TryRead<T>` automatically handles type size calculations
+- `TryReadBlock<T>(int blockLength, out T value)` advances by wire blockLength, not sizeof(T)
+- When `blockLength > sizeof(T)` (newer schema): reads struct and skips extra bytes (forward compat)
+- When `blockLength < sizeof(T)` (older schema): partial read with zero-padded trailing fields (backward compat)
+- When `blockLength == 0` (data-only groups): returns `default(T)` without advancing
 - Failed reads are gracefully handled with boolean returns
-- Older/newer message versions can be parsed without errors
+
+### ✅ Zero-Copy Decode
+- `ReadBlockRef<T>(int blockLength)` returns `ref readonly T` directly into the buffer (zero copies)
+- Returns `Unsafe.NullRef<T>()` on failure — check with `Unsafe.IsNullRef(ref value)`
+- Generated group callbacks use `in` delegates to pass structs by readonly reference
 
 ### ✅ Memory Alignment
 The SpanReader uses `MemoryMarshal.Read<T>` which properly handles:
@@ -135,14 +143,20 @@ Added comprehensive integration tests:
 ## Migration Impact
 
 ### For Code Generator Maintainers
-- Changes are internal to code generation
-- No public API changes
-- Existing tests updated and passing
+- SpanReader now has `TryReadBlock<T>` and `ReadBlockRef<T>` in addition to `TryRead<T>`
+- Group callbacks generate custom delegate types with `in` parameters
+- Nested groups use depth-indexed variable names (`nestedData1`, `nestedData2`)
 
 ### For Library Users
-- **No Breaking Changes**: Generated code signatures remain the same
-- **Transparent Integration**: Existing code using `ConsumeVariableLengthSegments` works without modification
-- **Same Behavior**: Functionally equivalent to previous implementation
+- **Breaking Change (v0.9.0)**: Group callbacks changed from `Action<GroupData>` to `{GroupName}Handler(in GroupData data)`. Add `in` keyword to lambda parameters:
+  ```csharp
+  // Before:
+  decoded.ConsumeVariableLengthSegments(buffer, bid => ProcessBid(bid));
+  // After:
+  decoded.ConsumeVariableLengthSegments(buffer, (in BidsData bid) => ProcessBid(bid));
+  ```
+- `TryParse` now uses `TryReadBlock<T>` internally for correct schema evolution handling
+- Generated `readonly` property getters prevent defensive copies when accessed through `in` refs
 
 ## Files Modified
 

--- a/docs/SPAN_READER_README.md
+++ b/docs/SPAN_READER_README.md
@@ -140,7 +140,7 @@ if (reader.CanRead(16))
 public bool TryRead<T>(out T value) where T : struct
 ```
 
-Attempts to read a blittable structure from the buffer and advances the reader position.
+Attempts to read a blittable structure from the buffer and advances by `Unsafe.SizeOf<T>()` bytes. Best for fixed-size types where `sizeof(T)` matches the wire size (e.g., headers, composites).
 
 **Example**:
 ```csharp
@@ -148,6 +148,48 @@ if (reader.TryRead<MessageHeader>(out var header))
 {
     Console.WriteLine($"Header: {header.TemplateId}");
 }
+```
+
+#### TryReadBlock<T>
+```csharp
+public bool TryReadBlock<T>(int blockLength, out T value) where T : struct
+```
+
+Reads a struct from the buffer advancing by `blockLength` bytes (wire size) instead of `sizeof(T)`. Handles schema evolution:
+- `blockLength == 0`: Returns `default(T)` (data-only groups)
+- `blockLength < sizeof(T)`: Partial read with zero-padded trailing fields (backward compat)
+- `blockLength >= sizeof(T)`: Full read, skips extra bytes (forward compat)
+
+**Example**:
+```csharp
+if (reader.TryRead<GroupSizeEncoding>(out var groupHeader))
+{
+    for (int i = 0; i < groupHeader.NumInGroup; i++)
+    {
+        if (reader.TryReadBlock<BidsData>(groupHeader.BlockLength, out var bid))
+            ProcessBid(bid);
+    }
+}
+```
+
+#### ReadBlockRef<T>
+```csharp
+public ref readonly T ReadBlockRef<T>(int blockLength) where T : struct
+```
+
+Returns a `ref readonly` directly into the buffer — **zero copies**. Advances by `blockLength` bytes. Returns `Unsafe.NullRef<T>()` when `blockLength == 0` or buffer is exhausted.
+
+**Example**:
+```csharp
+ref readonly var entry = ref reader.ReadBlockRef<EntryData>(blockLength);
+if (!Unsafe.IsNullRef(ref Unsafe.AsRef(in entry)))
+{
+    // Access fields directly from the buffer — no copy
+    Console.WriteLine(entry.Price);
+}
+```
+
+> ⚠️ The returned reference is only valid while the underlying buffer is alive. Do not store it beyond the buffer's lifetime.
 ```
 
 #### TryReadBytes
@@ -306,12 +348,26 @@ if (reader.TryPeek<MessageHeader>(out var header))
 }
 ```
 
-### Callback Pattern
+### Callback Pattern (v0.9.0+)
+
+Generated code uses custom delegates with `in` parameters to avoid struct copies:
 
 ```csharp
-void ProcessGroups(ReadOnlySpan<byte> buffer, 
-    Action<BidEntry> onBid, 
-    Action<AskEntry> onAsk)
+// Generated delegates:
+// public delegate void BidsHandler(in BidsData data);
+// public delegate void AsksHandler(in AsksData data);
+
+decoded.ConsumeVariableLengthSegments(
+    variableData,
+    (in BidsData bid) => Console.WriteLine($"Bid: {bid.Price}"),
+    (in AsksData ask) => Console.WriteLine($"Ask: {ask.Price}")
+);
+```
+
+For manual parsing with TryReadBlock:
+
+```csharp
+void ProcessGroups(ReadOnlySpan<byte> buffer)
 {
     var reader = new SpanReader(buffer);
     
@@ -320,8 +376,9 @@ void ProcessGroups(ReadOnlySpan<byte> buffer,
     {
         for (int i = 0; i < bids.NumInGroup; i++)
         {
-            if (reader.TryRead<BidEntry>(out var bid))
-                onBid(bid);
+            if (!reader.TryReadBlock<BidEntry>(bids.BlockLength, out var bid))
+                break;
+            ProcessBid(in bid);
         }
     }
     
@@ -330,8 +387,9 @@ void ProcessGroups(ReadOnlySpan<byte> buffer,
     {
         for (int i = 0; i < asks.NumInGroup; i++)
         {
-            if (reader.TryRead<AskEntry>(out var ask))
-                onAsk(ask);
+            if (!reader.TryReadBlock<AskEntry>(asks.BlockLength, out var ask))
+                break;
+            ProcessAsk(in ask);
         }
     }
 }
@@ -494,11 +552,6 @@ if (reader.TryRead<MessageHeader>(out var header))
         // Continue with standard reads
         if (reader.TryRead<Footer>(out var footer))
         {
-            ProcessMessage(header, content, footer);
-        }
-    }
-}
-```
             ProcessMessage(header, content, footer);
         }
     }

--- a/src/SbeCodeGenerator/EndianFieldHelper.cs
+++ b/src/SbeCodeGenerator/EndianFieldHelper.cs
@@ -68,7 +68,7 @@ namespace SbeSourceGenerator
                 : SetterExpression(primitiveType, "value", conversion);
 
             sb.AppendTabs(tabs).Append("public ").Append(declaredType).Append(" ").Append(name)
-                .Append(" { get => ").Append(getExpr)
+                .Append(" { readonly get => ").Append(getExpr)
                 .Append("; set => ").Append(fieldName).Append(" = ").Append(setExpr)
                 .AppendLine("; }");
         }

--- a/src/SbeCodeGenerator/FileContentGeneratorExtensions.cs
+++ b/src/SbeCodeGenerator/FileContentGeneratorExtensions.cs
@@ -43,7 +43,7 @@ namespace SbeSourceGenerator
                 return;
 
             sb.AppendLine("/// <summary>Returns a string representation of this struct for debugging.</summary>", tabs);
-            sb.AppendTabs(tabs).Append("public override string ToString() => $\"").Append(structName).Append(" {{ ");
+            sb.AppendTabs(tabs).Append("public readonly override string ToString() => $\"").Append(structName).Append(" {{ ");
 
             for (int i = 0; i < fieldNames.Count; i++)
             {

--- a/src/SbeCodeGenerator/Generators/Fields/OptionalMessageFieldDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Fields/OptionalMessageFieldDefinition.cs
@@ -56,11 +56,11 @@ namespace SbeSourceGenerator
 
                 if (NullValue == null && TypesCatalog.IsFloatingPoint(PrimitiveType))
                 {
-                    sb.AppendTabs(tabs).Append("public ").Append(Type).Append("? ").Append(Name).Append(" => ").Append(PrimitiveType).Append(".IsNaN((").Append(PrimitiveType).Append(")").Append(getExpr).Append(") ? null : ").Append(getExpr).AppendLine(";");
+                    sb.AppendTabs(tabs).Append("public readonly ").Append(Type).Append("? ").Append(Name).Append(" => ").Append(PrimitiveType).Append(".IsNaN((").Append(PrimitiveType).Append(")").Append(getExpr).Append(") ? null : ").Append(getExpr).AppendLine(";");
                 }
                 else
                 {
-                    sb.AppendTabs(tabs).Append("public ").Append(Type).Append("? ").Append(Name).Append(" => (").Append(PrimitiveType).Append(")").Append(getExpr).Append(" == ").Append(nullValue).Append(" ? null : ").Append(getExpr).AppendLine(";");
+                    sb.AppendTabs(tabs).Append("public readonly ").Append(Type).Append("? ").Append(Name).Append(" => (").Append(PrimitiveType).Append(")").Append(getExpr).Append(" == ").Append(nullValue).Append(" ? null : ").Append(getExpr).AppendLine(";");
                 }
                 sb.AppendTabs(tabs).Append("public void Set").Append(Name).Append("(").Append(Type).Append("? value) => ").Append(fieldName).Append(" = value.HasValue ? (").Append(Type).Append(")").Append(EndianFieldHelper.SetterExpression(PrimitiveType, "value.Value", EndianConversion)).Append(" : ").Append(setNullExpr).AppendLine(";");
             }

--- a/src/SbeCodeGenerator/Generators/SpanReaderGenerator.cs
+++ b/src/SbeCodeGenerator/Generators/SpanReaderGenerator.cs
@@ -104,12 +104,12 @@ namespace SbeSourceGenerator
                         }
 
                         /// <summary>
-                        /// Attempts to read a group entry using the wire blockLength rather than sizeof(T).
-                        /// Advances by exactly blockLength bytes, handling zero-field groups (blockLength=0)
+                        /// Attempts to read a block using the wire blockLength rather than sizeof(T).
+                        /// Advances by exactly blockLength bytes, handling zero-field structs (blockLength=0)
                         /// and schema evolution (blockLength differs from sizeof(T)).
                         /// </summary>
                         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                        public bool TryReadGroupEntry<T>(int blockLength, out T value) where T : struct
+                        public bool TryReadBlock<T>(int blockLength, out T value) where T : struct
                         {
                             value = default;
                             if (blockLength <= 0)
@@ -118,9 +118,33 @@ namespace SbeSourceGenerator
                                 return false;
                             int size = Unsafe.SizeOf<T>();
                             if (blockLength >= size)
+                            {
                                 value = MemoryMarshal.Read<T>(_buffer);
+                            }
+                            else
+                            {
+                                // Partial read: copy available bytes into a zeroed struct (backward compat)
+                                Span<byte> temp = stackalloc byte[size];
+                                _buffer.Slice(0, blockLength).CopyTo(temp);
+                                value = MemoryMarshal.Read<T>(temp);
+                            }
                             _buffer = _buffer.Slice(blockLength);
                             return true;
+                        }
+
+                        /// <summary>
+                        /// Returns a readonly reference directly into the buffer (zero-copy).
+                        /// Advances by exactly blockLength bytes.
+                        /// Returns Unsafe.NullRef when blockLength is 0 or buffer is exhausted.
+                        /// </summary>
+                        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                        public ref readonly T ReadBlockRef<T>(int blockLength) where T : struct
+                        {
+                            if (blockLength <= 0 || _buffer.Length < blockLength)
+                                return ref Unsafe.NullRef<T>();
+                            ref byte start = ref MemoryMarshal.GetReference(_buffer);
+                            _buffer = _buffer.Slice(blockLength);
+                            return ref Unsafe.As<byte, T>(ref start);
                         }
 
                         /// <summary>

--- a/src/SbeCodeGenerator/Generators/SpanReaderGenerator.cs
+++ b/src/SbeCodeGenerator/Generators/SpanReaderGenerator.cs
@@ -104,6 +104,26 @@ namespace SbeSourceGenerator
                         }
 
                         /// <summary>
+                        /// Attempts to read a group entry using the wire blockLength rather than sizeof(T).
+                        /// Advances by exactly blockLength bytes, handling zero-field groups (blockLength=0)
+                        /// and schema evolution (blockLength differs from sizeof(T)).
+                        /// </summary>
+                        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                        public bool TryReadGroupEntry<T>(int blockLength, out T value) where T : struct
+                        {
+                            value = default;
+                            if (blockLength <= 0)
+                                return true;
+                            if (_buffer.Length < blockLength)
+                                return false;
+                            int size = Unsafe.SizeOf<T>();
+                            if (blockLength >= size)
+                                value = MemoryMarshal.Read<T>(_buffer);
+                            _buffer = _buffer.Slice(blockLength);
+                            return true;
+                        }
+
+                        /// <summary>
                         /// Attempts to read the specified number of bytes from the buffer and advances the reader position.
                         /// </summary>
                         /// <param name="count">Number of bytes to read.</param>

--- a/src/SbeCodeGenerator/Generators/Types/MessageDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Types/MessageDefinition.cs
@@ -46,9 +46,9 @@ namespace SbeSourceGenerator
         public void AppendFileContent(StringBuilder sb, int tabs = 0)
         {
             if (EndianConversion != EndianConversion.None)
-                sb.AppendUsings(tabs, RuntimeNamespace, $"{RuntimeNamespace}.Runtime", "System.Runtime.CompilerServices", "System.Buffers.Binary");
+                sb.AppendUsings(tabs, RuntimeNamespace, $"{RuntimeNamespace}.Runtime", "System.Runtime.CompilerServices", "System.Runtime.InteropServices", "System.Buffers.Binary");
             else
-                sb.AppendUsings(tabs, RuntimeNamespace, $"{RuntimeNamespace}.Runtime", "System.Runtime.CompilerServices");
+                sb.AppendUsings(tabs, RuntimeNamespace, $"{RuntimeNamespace}.Runtime", "System.Runtime.CompilerServices", "System.Runtime.InteropServices");
 
             sb.AppendStructDefinition(tabs, Description, Name, nameof(MessageDefinition), Namespace);
 
@@ -87,58 +87,20 @@ namespace SbeSourceGenerator
             sb.AppendTabs(tabs).Append("public static bool TryParse(ReadOnlySpan<byte> buffer, int blockLength, out ").Append(Name).AppendLine("Data message, out ReadOnlySpan<byte> variableData)");
             sb.AppendLine("{", tabs++);
             sb.AppendLine("var reader = new SpanReader(buffer);", tabs);
-            sb.AppendLine("// Read the message data", tabs);
-            sb.AppendTabs(tabs).Append("if (!reader.TryRead<").Append(Name).AppendLine("Data>(out message))");
-            sb.AppendLine("{", tabs++);
-            sb.AppendLine("variableData = default;", tabs);
-            sb.AppendLine("return false;", tabs);
-            sb.AppendLine("}", --tabs);
-            sb.AppendLine("", tabs);
-            sb.AppendLine("// Handle schema evolution: skip additional bytes if blockLength > MESSAGE_SIZE", tabs);
-            sb.AppendLine("var additionalBytes = blockLength - MESSAGE_SIZE;", tabs);
-            sb.AppendLine("if (additionalBytes > 0)", tabs);
-            sb.AppendLine("{", tabs++);
-            sb.AppendLine("if (!reader.TrySkip(additionalBytes))", tabs);
+            sb.AppendTabs(tabs).Append("if (!reader.TryReadBlock<").Append(Name).AppendLine("Data>(blockLength, out message))");
             sb.AppendLine("{", tabs++);
             sb.AppendLine("variableData = default;", tabs);
             sb.AppendLine("return false;", tabs);
             sb.AppendLine("}", --tabs);
             sb.AppendLine("variableData = reader.Remaining;", tabs);
-            sb.AppendLine("}", --tabs);
-            sb.AppendLine("else", tabs);
-            sb.AppendLine("{", tabs++);
-            sb.AppendLine("// For backward compatibility: variable data starts at blockLength", tabs);
-            sb.AppendLine("if (blockLength > buffer.Length)", tabs);
-            sb.AppendLine("{", tabs++);
-            sb.AppendLine("variableData = default;", tabs);
-            sb.AppendLine("return false;", tabs);
-            sb.AppendLine("}", --tabs);
-            sb.AppendLine("variableData = buffer.Slice(blockLength);", tabs);
-            sb.AppendLine("}", --tabs);
-            sb.AppendLine("", tabs);
             sb.AppendLine("return true;", tabs);
             sb.AppendLine("}", --tabs);
 
             // Public method that uses SpanReader for parsing - reader is passed by ref to update offset in caller
-            // This method is designed for advanced scenarios where users manage their own SpanReader
-            // Caller can access remaining data via reader.Remaining after successful parse
             sb.AppendLine("[MethodImpl(MethodImplOptions.AggressiveInlining)]", tabs);
             sb.AppendTabs(tabs).Append("public static bool TryParseWithReader(ref SpanReader reader, int blockLength, out ").Append(Name).AppendLine("Data message)");
             sb.AppendLine("{", tabs++);
-            sb.AppendLine("// Read the message data", tabs);
-            sb.AppendTabs(tabs).Append("if (!reader.TryRead<").Append(Name).AppendLine("Data>(out message))");
-            sb.AppendLine("{", tabs++);
-            sb.AppendLine("return false;", tabs);
-            sb.AppendLine("}", --tabs);
-            sb.AppendLine("", tabs);
-            sb.AppendLine("// Handle schema evolution: skip additional bytes if blockLength > MESSAGE_SIZE", tabs);
-            sb.AppendLine("var additionalBytes = blockLength - MESSAGE_SIZE;", tabs);
-            sb.AppendLine("if (additionalBytes > 0 && !reader.TrySkip(additionalBytes))", tabs);
-            sb.AppendLine("{", tabs++);
-            sb.AppendLine("return false;", tabs);
-            sb.AppendLine("}", --tabs);
-            sb.AppendLine("", tabs);
-            sb.AppendLine("return true;", tabs);
+            sb.AppendTabs(tabs).Append("return reader.TryReadBlock<").Append(Name).AppendLine("Data>(blockLength, out message);");
             sb.AppendLine("}", --tabs);
         }
 
@@ -263,6 +225,10 @@ namespace SbeSourceGenerator
         {
             if (HasVariableData)
             {
+                // Generate delegate types for zero-copy group callbacks
+                foreach (var group in TypedGroups)
+                    AppendGroupDelegateTypes(sb, tabs, group);
+
                 // Build callback parameter lists once
                 var callbackParams = BuildCallbackParams();
                 var callbackArgs = BuildCallbackArgs();
@@ -301,19 +267,18 @@ namespace SbeSourceGenerator
             sb.AppendLine("{", tabs++);
             sb.AppendTabs(tabs).Append("for (int ").Append(loopVar).Append(" = 0; ").Append(loopVar).Append(" < group").Append(group.Name).Append(".NumInGroup; ").Append(loopVar).AppendLine("++)");
             sb.AppendLine("{", tabs++);
-            // Use TryReadGroupEntry with blockLength from header to handle zero-field groups and schema evolution
-            sb.AppendTabs(tabs).Append("if (!reader.TryReadGroupEntry<").Append(group.Name).Append("Data>(group").Append(group.Name).Append(".BlockLength, out var ").Append(dataVarName).AppendLine("))");
+            sb.AppendTabs(tabs).Append("if (!reader.TryReadBlock<").Append(group.Name).Append("Data>(group").Append(group.Name).Append(".BlockLength, out var ").Append(dataVarName).AppendLine("))");
             sb.AppendLine("{", tabs++);
             sb.AppendLine("break;", tabs);
             sb.AppendLine("}", --tabs);
 
-            // Invoke callback with ancestor context
+            // Invoke callback with ancestor context using 'in' for zero-copy pass
             sb.AppendTabs(tabs).Append("callback").Append(group.Name).Append("(");
             foreach (var ancestorVar in ancestors)
             {
-                sb.Append(ancestorVar).Append(", ");
+                sb.Append("in ").Append(ancestorVar).Append(", ");
             }
-            sb.Append(dataVarName).AppendLine(");");
+            sb.Append("in ").Append(dataVarName).AppendLine(");");
 
             // Read group-level variable data after each entry
             foreach (var groupData in group.TypedDatas)
@@ -331,6 +296,22 @@ namespace SbeSourceGenerator
             }
             sb.AppendLine("}", --tabs);
             sb.AppendLine("}", --tabs);
+        }
+
+        private static void AppendGroupDelegateTypes(StringBuilder sb, int tabs, GroupDefinition group, List<string>? ancestorTypes = null)
+        {
+            var ancestors = ancestorTypes ?? new List<string>();
+            var paramParts = new List<string>();
+            foreach (var ancestor in ancestors)
+                paramParts.Add($"in {ancestor} {char.ToLowerInvariant(ancestor[0])}{ancestor.Substring(1)}");
+            paramParts.Add($"in {group.Name}Data data");
+            sb.AppendTabs(tabs).Append("public delegate void ").Append(group.Name).Append("Handler(")
+                .Append(string.Join(", ", paramParts)).AppendLine(");");
+
+            var ancestorsForChildren = new List<string>(ancestors);
+            ancestorsForChildren.Add($"{group.Name}Data");
+            foreach (var nestedGroup in group.TypedNestedGroups)
+                AppendGroupDelegateTypes(sb, tabs, nestedGroup, ancestorsForChildren);
         }
 
         private void AppendGroupsFileContent(StringBuilder sb, int tabs)
@@ -599,15 +580,7 @@ namespace SbeSourceGenerator
         private static void AppendGroupCallbackParams(List<string> parts, GroupDefinition group, List<string>? ancestorTypes = null)
         {
             var ancestors = ancestorTypes ?? new List<string>();
-            if (ancestors.Count == 0)
-            {
-                parts.Add($"Action<{group.Name}Data> callback{group.Name}");
-            }
-            else
-            {
-                var typeArgs = string.Join(", ", ancestors) + $", {group.Name}Data";
-                parts.Add($"Action<{typeArgs}> callback{group.Name}");
-            }
+            parts.Add($"{group.Name}Handler callback{group.Name}");
 
             foreach (var groupData in group.TypedDatas)
                 parts.Add($"{groupData.Type}.Callback callback{group.Name}{groupData.Name}");

--- a/src/SbeCodeGenerator/Generators/Types/MessageDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Types/MessageDefinition.cs
@@ -301,7 +301,8 @@ namespace SbeSourceGenerator
             sb.AppendLine("{", tabs++);
             sb.AppendTabs(tabs).Append("for (int ").Append(loopVar).Append(" = 0; ").Append(loopVar).Append(" < group").Append(group.Name).Append(".NumInGroup; ").Append(loopVar).AppendLine("++)");
             sb.AppendLine("{", tabs++);
-            sb.AppendTabs(tabs).Append("if (!reader.TryRead<").Append(group.Name).Append("Data>(out var ").Append(dataVarName).AppendLine("))");
+            // Use TryReadGroupEntry with blockLength from header to handle zero-field groups and schema evolution
+            sb.AppendTabs(tabs).Append("if (!reader.TryReadGroupEntry<").Append(group.Name).Append("Data>(group").Append(group.Name).Append(".BlockLength, out var ").Append(dataVarName).AppendLine("))");
             sb.AppendLine("{", tabs++);
             sb.AppendLine("break;", tabs);
             sb.AppendLine("}", --tabs);

--- a/src/SbeCodeGenerator/Generators/Types/MessageDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Types/MessageDefinition.cs
@@ -260,8 +260,9 @@ namespace SbeSourceGenerator
         private static void AppendGroupConsume(StringBuilder sb, int tabs, GroupDefinition group, List<string>? ancestorVarNames = null)
         {
             var ancestors = ancestorVarNames ?? new List<string>();
-            var dataVarName = ancestors.Count == 0 ? "data" : "nestedData";
-            var loopVar = ancestors.Count == 0 ? "i" : $"j{ancestors.Count}";
+            var depth = ancestors.Count;
+            var dataVarName = depth == 0 ? "data" : $"nestedData{depth}";
+            var loopVar = depth == 0 ? "i" : $"j{depth}";
 
             sb.AppendTabs(tabs).Append("if (reader.TryRead<").Append(group.DimensionType).Append(">(out var group").Append(group.Name).AppendLine("))");
             sb.AppendLine("{", tabs++);
@@ -319,13 +320,19 @@ namespace SbeSourceGenerator
             foreach (var group in Groups)
             {
                 group.AppendFileContent(sb, tabs);
-                // Also generate nested group structs
                 var typedGroup = (GroupDefinition)group;
-                if (typedGroup.HasNestedGroups)
-                {
-                    foreach (var nested in typedGroup.NestedGroups!)
-                        nested.AppendFileContent(sb, tabs);
-                }
+                AppendNestedGroupStructs(sb, tabs, typedGroup);
+            }
+        }
+
+        private static void AppendNestedGroupStructs(StringBuilder sb, int tabs, GroupDefinition group)
+        {
+            if (!group.HasNestedGroups)
+                return;
+            foreach (var nested in group.NestedGroups!)
+            {
+                nested.AppendFileContent(sb, tabs);
+                AppendNestedGroupStructs(sb, tabs, (GroupDefinition)nested);
             }
         }
 

--- a/src/SbeCodeGenerator/Generators/TypesCodeGenerator.cs
+++ b/src/SbeCodeGenerator/Generators/TypesCodeGenerator.cs
@@ -15,9 +15,11 @@ namespace SbeSourceGenerator.Generators
     {
         public IEnumerable<(string name, string content)> Generate(string ns, ParsedSchema schema, SchemaContext context, SourceProductionContext sourceContext)
         {
-            foreach (var compositeDto in schema.Composites)
+            // Types, enums, and sets must be processed before composites
+            // because composites may reference them via <ref> fields.
+            foreach (var typeDto in schema.Types)
             {
-                foreach (var item in GenerateComposite(ns, compositeDto, context, sourceContext))
+                foreach (var item in GenerateType(ns, typeDto, context, sourceContext))
                     yield return item;
             }
             foreach (var enumDto in schema.Enums)
@@ -25,14 +27,14 @@ namespace SbeSourceGenerator.Generators
                 foreach (var item in GenerateEnum(ns, enumDto, context, sourceContext))
                     yield return item;
             }
-            foreach (var typeDto in schema.Types)
-            {
-                foreach (var item in GenerateType(ns, typeDto, context, sourceContext))
-                    yield return item;
-            }
             foreach (var setDto in schema.Sets)
             {
                 foreach (var item in GenerateSet(ns, setDto, context, sourceContext))
+                    yield return item;
+            }
+            foreach (var compositeDto in schema.Composites)
+            {
+                foreach (var item in GenerateComposite(ns, compositeDto, context, sourceContext))
                     yield return item;
             }
         }
@@ -69,7 +71,7 @@ namespace SbeSourceGenerator.Generators
                     return true;
                 })
                 .Select(x => new EnumFieldDefinition(
-                    x.choice.Name,
+                    TypeTranslator.NormalizeName(x.choice.Name),
                     x.choice.Description,
                     x.parsedValue?.ToString() ?? "0",
                     x.choice.SinceVersion,
@@ -201,7 +203,7 @@ namespace SbeSourceGenerator.Generators
                     TypesCatalog.GetPrimitiveLength(encodingTranslated.PrimitiveType),
                     enumDto.Choices
                         .Select(choice => new EnumFieldDefinition(
-                            choice.Name,
+                            TypeTranslator.NormalizeName(choice.Name),
                             choice.Description,
                             choice.InnerText,
                             choice.SinceVersion,
@@ -218,7 +220,7 @@ namespace SbeSourceGenerator.Generators
                     TypesCatalog.GetPrimitiveLength(encodingTranslated.PrimitiveType),
                     enumDto.Choices
                         .Select(choice => new EnumFieldDefinition(
-                            choice.Name,
+                            TypeTranslator.NormalizeName(choice.Name),
                             choice.Description,
                             choice.InnerText,
                             choice.SinceVersion,
@@ -297,43 +299,75 @@ namespace SbeSourceGenerator.Generators
                 context.CompositeFieldTypes[$"{compositeDto.Name}.{rf.Name}"] = resolvedRefType;
             }
 
+            // Generate InlineArray types for char fields with length > 1
+            var charArrayTypes = new Dictionary<string, (string GeneratedName, int Length)>();
+            foreach (var ft in fieldTranslations)
+            {
+                if (ft.Translation.PrimitiveType == "char" && ft.Field.Presence != "constant"
+                    && int.TryParse(ft.Field.Length, out var charLen) && charLen > 1)
+                {
+                    var charTypeName = TypeResolverHelper.RegisterGeneratedTypeName(context, ft.Field.Name, sourceContext);
+                    var charTypeDef = new FixedSizeCharTypeDefinition(ns, charTypeName, ft.Field.Description, charLen, ft.Field.CharacterEncoding);
+                    context.CustomTypeLengths[ft.Field.Name] = charLen;
+                    charArrayTypes[ft.Field.Name] = (charTypeName, charLen);
+                    var charSb = new StringBuilder(256);
+                    charTypeDef.AppendFileContent(charSb);
+                    yield return (context.CreateHintName(ns, "Types", charTypeName), charSb.ToString());
+                }
+            }
+
             // Build field definitions preserving original order
             var fields = new List<IFileContentGenerator>(compositeDto.Fields.Count);
             foreach (var field in compositeDto.Fields)
             {
                 if (!string.IsNullOrEmpty(field.PrimitiveType))
                 {
-                    var ft = fieldTranslations.First(x => x.Field == field);
-                    fields.Add((ft.Field.Presence, ft.Field.Length) switch
+                    var ft = fieldTranslations.FirstOrDefault(x => x.Field == field);
+                    if (ft == null) continue;
+
+                    // Char array fields use the generated InlineArray type
+                    if (charArrayTypes.TryGetValue(ft.Field.Name, out var charArrayInfo))
                     {
-                        ("constant", _) => new ConstantTypeFieldDefinition(
+                        fields.Add(new CompositeRefFieldDefinition(
                             TypeTranslator.NormalizeName(ft.Field.Name),
                             ft.Field.Description,
-                            TypeResolverHelper.ResolveTypeName(ft.Translation.PrimitiveType, context),
-                            InsertQuotationsIfNeeded(ft.Field.InnerText, ft.Field.PrimitiveType, ft.Field.Length),
-                            TypeResolverHelper.NormalizeValueRef(ft.Field.ValueRef, context)
-                        ),
-                        ("optional", _) => new NullableValueFieldDefinition(
-                            TypeTranslator.NormalizeName(ft.Field.Name),
-                            ft.Field.Description,
-                            TypeResolverHelper.ResolveTypeName(ft.Translation.PrimitiveType, context),
-                            TypeResolverHelper.GetTypeLength(ft.Translation.PrimitiveType, context),
-                            ft.Field.NullValue == "" ? null : ft.Field.NullValue,
-                            context.EndianConversion
-                        ),
-                        ("", "0") => new ArrayFieldDefinition(
-                            TypeTranslator.NormalizeName(ft.Field.Name),
-                            ft.Field.Description,
-                            "byte"
-                        ),
-                        _ => (IFileContentGenerator)new ValueFieldDefinition(
-                            TypeTranslator.NormalizeName(ft.Field.Name),
-                            ft.Field.Description,
-                            TypeResolverHelper.ResolveTypeName(ft.Translation.PrimitiveType, context),
-                            TypeResolverHelper.GetTypeLength(ft.Translation.PrimitiveType, context),
-                            context.EndianConversion
-                        )
-                    });
+                            charArrayInfo.GeneratedName,
+                            charArrayInfo.Length
+                        ));
+                    }
+                    else
+                    {
+                        fields.Add((ft.Field.Presence, ft.Field.Length) switch
+                        {
+                            ("constant", _) => new ConstantTypeFieldDefinition(
+                                TypeTranslator.NormalizeName(ft.Field.Name),
+                                ft.Field.Description,
+                                TypeResolverHelper.ResolveTypeName(ft.Translation.PrimitiveType, context),
+                                InsertQuotationsIfNeeded(ft.Field.InnerText, ft.Field.PrimitiveType, ft.Field.Length),
+                                TypeResolverHelper.NormalizeValueRef(ft.Field.ValueRef, context)
+                            ),
+                            ("optional", _) => new NullableValueFieldDefinition(
+                                TypeTranslator.NormalizeName(ft.Field.Name),
+                                ft.Field.Description,
+                                TypeResolverHelper.ResolveTypeName(ft.Translation.PrimitiveType, context),
+                                TypeResolverHelper.GetTypeLength(ft.Translation.PrimitiveType, context),
+                                ft.Field.NullValue == "" ? null : ft.Field.NullValue,
+                                context.EndianConversion
+                            ),
+                            ("", "0") => new ArrayFieldDefinition(
+                                TypeTranslator.NormalizeName(ft.Field.Name),
+                                ft.Field.Description,
+                                "byte"
+                            ),
+                            _ => (IFileContentGenerator)new ValueFieldDefinition(
+                                TypeTranslator.NormalizeName(ft.Field.Name),
+                                ft.Field.Description,
+                                TypeResolverHelper.ResolveTypeName(ft.Translation.PrimitiveType, context),
+                                TypeResolverHelper.GetTypeLength(ft.Translation.PrimitiveType, context),
+                                context.EndianConversion
+                            )
+                        });
+                    }
                 }
                 else if (!string.IsNullOrEmpty(field.Type))
                 {

--- a/src/SbeCodeGenerator/Runtime/SpanReader.cs
+++ b/src/SbeCodeGenerator/Runtime/SpanReader.cs
@@ -113,6 +113,30 @@ namespace SbeSourceGenerator.Runtime
         }
 
         /// <summary>
+        /// Attempts to read a group entry using the wire blockLength rather than sizeof(T).
+        /// Advances by exactly blockLength bytes, handling zero-field groups (blockLength=0)
+        /// and schema evolution (blockLength differs from sizeof(T)).
+        /// </summary>
+        /// <typeparam name="T">The type of structure to read. Must be a blittable type.</typeparam>
+        /// <param name="blockLength">The wire blockLength from the group header.</param>
+        /// <param name="value">When this method returns, contains the read value if successful; otherwise, the default value.</param>
+        /// <returns>True if the entry was successfully processed; false if buffer exhausted.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryReadGroupEntry<T>(int blockLength, out T value) where T : struct
+        {
+            value = default;
+            if (blockLength <= 0)
+                return true;
+            if (_buffer.Length < blockLength)
+                return false;
+            int size = Unsafe.SizeOf<T>();
+            if (blockLength >= size)
+                value = MemoryMarshal.Read<T>(_buffer);
+            _buffer = _buffer.Slice(blockLength);
+            return true;
+        }
+
+        /// <summary>
         /// Attempts to read the specified number of bytes from the buffer and advances the reader position.
         /// </summary>
         /// <param name="count">Number of bytes to read.</param>

--- a/src/SbeCodeGenerator/Runtime/SpanReader.cs
+++ b/src/SbeCodeGenerator/Runtime/SpanReader.cs
@@ -113,16 +113,16 @@ namespace SbeSourceGenerator.Runtime
         }
 
         /// <summary>
-        /// Attempts to read a group entry using the wire blockLength rather than sizeof(T).
-        /// Advances by exactly blockLength bytes, handling zero-field groups (blockLength=0)
+        /// Attempts to read a block using the wire blockLength rather than sizeof(T).
+        /// Advances by exactly blockLength bytes, handling zero-field structs (blockLength=0)
         /// and schema evolution (blockLength differs from sizeof(T)).
         /// </summary>
         /// <typeparam name="T">The type of structure to read. Must be a blittable type.</typeparam>
-        /// <param name="blockLength">The wire blockLength from the group header.</param>
+        /// <param name="blockLength">The wire blockLength from the group/message header.</param>
         /// <param name="value">When this method returns, contains the read value if successful; otherwise, the default value.</param>
-        /// <returns>True if the entry was successfully processed; false if buffer exhausted.</returns>
+        /// <returns>True if the block was successfully processed; false if buffer exhausted.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool TryReadGroupEntry<T>(int blockLength, out T value) where T : struct
+        public bool TryReadBlock<T>(int blockLength, out T value) where T : struct
         {
             value = default;
             if (blockLength <= 0)
@@ -131,9 +131,37 @@ namespace SbeSourceGenerator.Runtime
                 return false;
             int size = Unsafe.SizeOf<T>();
             if (blockLength >= size)
+            {
                 value = MemoryMarshal.Read<T>(_buffer);
+            }
+            else
+            {
+                // Partial read: copy available bytes into a zeroed struct (backward compat)
+                Span<byte> temp = stackalloc byte[size];
+                _buffer.Slice(0, blockLength).CopyTo(temp);
+                value = MemoryMarshal.Read<T>(temp);
+            }
             _buffer = _buffer.Slice(blockLength);
             return true;
+        }
+
+        /// <summary>
+        /// Returns a readonly reference directly into the buffer (zero-copy).
+        /// Advances by exactly blockLength bytes.
+        /// Returns Unsafe.NullRef when blockLength is 0 or buffer is exhausted.
+        /// Check with Unsafe.IsNullRef before accessing the returned reference.
+        /// </summary>
+        /// <typeparam name="T">The type of structure to reference. Must be a blittable type.</typeparam>
+        /// <param name="blockLength">The wire blockLength from the group/message header.</param>
+        /// <returns>A readonly reference into the buffer, or NullRef if unavailable.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ref readonly T ReadBlockRef<T>(int blockLength) where T : struct
+        {
+            if (blockLength <= 0 || _buffer.Length < blockLength)
+                return ref Unsafe.NullRef<T>();
+            ref byte start = ref MemoryMarshal.GetReference(_buffer);
+            _buffer = _buffer.Slice(blockLength);
+            return ref Unsafe.As<byte, T>(ref start);
         }
 
         /// <summary>

--- a/src/SbeCodeGenerator/SbeSourceGenerator.csproj
+++ b/src/SbeCodeGenerator/SbeSourceGenerator.csproj
@@ -10,7 +10,7 @@
 		<NoWarn>$(NoWarn);CS1591</NoWarn>
 		<PackageId>SbeSourceGenerator</PackageId>
 		<Title>SBE Source Generator</Title>
-		<Version>0.8.0</Version>
+		<Version>0.9.0</Version>
 		<Authors>Pedro Sakuma</Authors>
 		<Company>Pedro Sakuma</Company>
 		<Product>SBE Source Generator</Product>

--- a/src/SbeCodeGenerator/Schema/SchemaFieldDto.cs
+++ b/src/SbeCodeGenerator/Schema/SchemaFieldDto.cs
@@ -19,6 +19,7 @@ namespace SbeSourceGenerator.Schema
         string SinceVersion,
         string MinValue,
         string MaxValue,
-        string Deprecated
+        string Deprecated,
+        string CharacterEncoding = ""
     );
 }

--- a/src/SbeCodeGenerator/Schema/SchemaReader.cs
+++ b/src/SbeCodeGenerator/Schema/SchemaReader.cs
@@ -352,6 +352,7 @@ namespace SbeSourceGenerator.Schema
             string minValue = reader.GetAttribute("minValue") ?? "";
             string maxValue = reader.GetAttribute("maxValue") ?? "";
             string deprecated = reader.GetAttribute("deprecated") ?? "";
+            string characterEncoding = reader.GetAttribute("characterEncoding") ?? "";
 
             // Read inner text manually to leave reader on the end element,
             // so the parent loop's reader.Read() correctly advances to the next sibling.
@@ -369,7 +370,7 @@ namespace SbeSourceGenerator.Schema
             }
 
             return new SchemaFieldDto(name, desc, primitiveType, presence, length, nullValue, valueRef,
-                innerText, fieldId, offset, type, sinceVersion, minValue, maxValue, deprecated);
+                innerText, fieldId, offset, type, sinceVersion, minValue, maxValue, deprecated, characterEncoding);
         }
 
         private static string GetRequiredAttribute(XmlReader reader, string attributeName, string elementName, SourceProductionContext sourceContext)

--- a/tests/SbeCodeGenerator.IntegrationTests/CarExampleIntegrationTests.cs
+++ b/tests/SbeCodeGenerator.IntegrationTests/CarExampleIntegrationTests.cs
@@ -283,7 +283,7 @@ namespace SbeCodeGenerator.IntegrationTests
             string? modelName = null;
 
             parsedCar.ConsumeVariableLengthSegments(variableData,
-                callbackFuelFigures: (CarData.FuelFiguresData fuel) =>
+                callbackFuelFigures: (in CarData.FuelFiguresData fuel) =>
                 {
                     fuelCount++;
                     Assert.Equal((ushort)60, fuel.Speed);
@@ -293,12 +293,12 @@ namespace SbeCodeGenerator.IntegrationTests
                 {
                     Assert.Equal("City", Encoding.ASCII.GetString(usageDesc.VarData));
                 },
-                callbackPerformanceFigures: (CarData.PerformanceFiguresData perf) =>
+                callbackPerformanceFigures: (in CarData.PerformanceFiguresData perf) =>
                 {
                     perfCount++;
                     Assert.Equal((byte)95, perf.OctaneRating.Value);
                 },
-                callbackAcceleration: (CarData.PerformanceFiguresData perf, CarData.AccelerationData accel) =>
+                callbackAcceleration: (in CarData.PerformanceFiguresData perf, in CarData.AccelerationData accel) =>
                 {
                     accelCount++;
                 },

--- a/tests/SbeCodeGenerator.IntegrationTests/CarExampleIntegrationTests.cs
+++ b/tests/SbeCodeGenerator.IntegrationTests/CarExampleIntegrationTests.cs
@@ -40,19 +40,22 @@ namespace SbeCodeGenerator.IntegrationTests
         }
 
         [Fact]
+        public unsafe void CarData_MessageSize_MatchesRuntimeSize()
+        {
+            Assert.Equal(CarData.MESSAGE_SIZE, sizeof(CarData));
+        }
+
+        [Fact]
         public unsafe void CarData_FixedFieldsRoundTrip()
         {
-            // Use sizeof to get the actual runtime struct size (may differ from MESSAGE_SIZE
-            // due to composite field sizing, which is computed from schema field widths)
-            int actualSize = sizeof(CarData);
-            Span<byte> buffer = stackalloc byte[actualSize];
+            Span<byte> buffer = stackalloc byte[CarData.MESSAGE_SIZE];
             ref CarData car = ref MemoryMarshal.AsRef<CarData>(buffer);
 
             car.SerialNumber = 1234567890UL;
             car.ModelYear = 2024;
             car.Available = BooleanType.T;
             car.Code = Model.B;
-            car.Extras = OptionalExtras.sunRoof | OptionalExtras.cruiseControl;
+            car.Extras = OptionalExtras.SunRoof | OptionalExtras.CruiseControl;
 
             car.Engine.Capacity = 2000;
             car.Engine.NumCylinders = 4;
@@ -61,9 +64,9 @@ namespace SbeCodeGenerator.IntegrationTests
             Assert.Equal((ushort)2024, car.ModelYear.Value);
             Assert.Equal(BooleanType.T, car.Available);
             Assert.Equal(Model.B, car.Code);
-            Assert.True((car.Extras & OptionalExtras.sunRoof) != 0);
-            Assert.True((car.Extras & OptionalExtras.cruiseControl) != 0);
-            Assert.True((car.Extras & OptionalExtras.sportsPack) == 0);
+            Assert.True((car.Extras & OptionalExtras.SunRoof) != 0);
+            Assert.True((car.Extras & OptionalExtras.CruiseControl) != 0);
+            Assert.True((car.Extras & OptionalExtras.SportsPack) == 0);
             Assert.Equal((ushort)2000, car.Engine.Capacity);
             Assert.Equal((byte)4, car.Engine.NumCylinders);
         }
@@ -77,8 +80,7 @@ namespace SbeCodeGenerator.IntegrationTests
         [Fact]
         public unsafe void CarData_TryParse_Works()
         {
-            int actualSize = sizeof(CarData);
-            Span<byte> buffer = stackalloc byte[actualSize];
+            Span<byte> buffer = stackalloc byte[CarData.MESSAGE_SIZE];
             ref CarData car = ref MemoryMarshal.AsRef<CarData>(buffer);
             car.SerialNumber = 42;
             car.Engine.Capacity = 1600;
@@ -99,8 +101,7 @@ namespace SbeCodeGenerator.IntegrationTests
             car.Available = BooleanType.F;
             car.Code = Model.A;
 
-            int actualSize = sizeof(CarData);
-            Span<byte> buffer = stackalloc byte[actualSize];
+            Span<byte> buffer = stackalloc byte[CarData.MESSAGE_SIZE];
             Assert.True(car.TryEncode(buffer, out int bytesWritten));
             Assert.Equal(CarData.MESSAGE_SIZE, bytesWritten);
 
@@ -198,7 +199,6 @@ namespace SbeCodeGenerator.IntegrationTests
         [Fact]
         public unsafe void CarData_ConsumeVariableLengthSegments_WithGroupData()
         {
-            int carSize = sizeof(CarData);
             var buffer = new byte[2048];
             var span = buffer.AsSpan();
             int offset = 0;
@@ -207,7 +207,7 @@ namespace SbeCodeGenerator.IntegrationTests
             ref CarData car = ref MemoryMarshal.AsRef<CarData>(span);
             car.SerialNumber = 42;
             car.Engine.Capacity = 2000;
-            offset += carSize;
+            offset += CarData.MESSAGE_SIZE;
 
             // fuelFigures group: 1 entry
             ref GroupSizeEncoding fuelGroupHeader = ref MemoryMarshal.AsRef<GroupSizeEncoding>(span.Slice(offset));
@@ -273,7 +273,7 @@ namespace SbeCodeGenerator.IntegrationTests
             // Parse: directly slice past the fixed fields since the struct size
             // includes padding from embedded composites
             var parsedCar = MemoryMarshal.AsRef<CarData>(span);
-            var variableData = span.Slice(carSize);
+            var variableData = span.Slice(CarData.MESSAGE_SIZE);
             Assert.Equal(42UL, parsedCar.SerialNumber);
 
             int fuelCount = 0;
@@ -326,11 +326,11 @@ namespace SbeCodeGenerator.IntegrationTests
         [Fact]
         public void OptionalExtras_SetOperations()
         {
-            var extras = OptionalExtras.sunRoof | OptionalExtras.sportsPack;
+            var extras = OptionalExtras.SunRoof | OptionalExtras.SportsPack;
 
-            Assert.True((extras & OptionalExtras.sunRoof) != 0);
-            Assert.True((extras & OptionalExtras.sportsPack) != 0);
-            Assert.True((extras & OptionalExtras.cruiseControl) == 0);
+            Assert.True((extras & OptionalExtras.SunRoof) != 0);
+            Assert.True((extras & OptionalExtras.SportsPack) != 0);
+            Assert.True((extras & OptionalExtras.CruiseControl) == 0);
         }
 
         [Fact]

--- a/tests/SbeCodeGenerator.IntegrationTests/CrossSchemaIntegrationTests.cs
+++ b/tests/SbeCodeGenerator.IntegrationTests/CrossSchemaIntegrationTests.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace SbeCodeGenerator.IntegrationTests;
+
+/// <summary>
+/// Tests that multiple SBE schemas can coexist in the same project without conflicts,
+/// and that types with the same name in different schemas are correctly isolated.
+/// </summary>
+public class CrossSchemaIntegrationTests
+{
+    [Fact]
+    public void SeparateSchemas_GenerateIsolatedNamespaces()
+    {
+        // Both schemas define Currency enum — verify they are distinct types
+        var commonCurrency = Cross.Schema.Common.V0.Currency.EUR;
+        var ordersCurrency = Cross.Schema.Orders.V0.Currency.EUR;
+
+        Assert.Equal((byte)1, (byte)commonCurrency);
+        Assert.Equal((byte)1, (byte)ordersCurrency);
+
+        // Verify they are different types (cannot assign one to the other)
+        Assert.Equal(typeof(Cross.Schema.Common.V0.Currency), commonCurrency.GetType());
+        Assert.Equal(typeof(Cross.Schema.Orders.V0.Currency), ordersCurrency.GetType());
+        Assert.NotEqual(commonCurrency.GetType(), ordersCurrency.GetType());
+    }
+
+    [Fact]
+    public void SeparateSchemas_MessageHeadersAreIndependent()
+    {
+        // Both schemas define MessageHeader — verify both are usable
+        Assert.Equal(8, Cross.Schema.Common.V0.MessageHeader.MESSAGE_SIZE);
+        Assert.Equal(8, Cross.Schema.Orders.V0.MessageHeader.MESSAGE_SIZE);
+
+        // Different types despite identical layout
+        Assert.NotEqual(
+            typeof(Cross.Schema.Common.V0.MessageHeader),
+            typeof(Cross.Schema.Orders.V0.MessageHeader));
+    }
+
+    [Fact]
+    public void CommonSchema_HeartbeatRoundTrip()
+    {
+        // Encode and decode Heartbeat from the common schema
+        Span<byte> buffer = stackalloc byte[Cross.Schema.Common.V0.HeartbeatData.MESSAGE_SIZE];
+        ref var msg = ref MemoryMarshal.AsRef<Cross.Schema.Common.V0.HeartbeatData>(buffer);
+        msg.Timestamp = 1234567890123456789UL;
+
+        var success = Cross.Schema.Common.V0.HeartbeatData.TryParse(
+            buffer,
+            Cross.Schema.Common.V0.HeartbeatData.MESSAGE_SIZE,
+            out var parsed,
+            out _);
+
+        Assert.True(success);
+        Assert.Equal(1234567890123456789UL, parsed.Timestamp);
+    }
+
+    [Fact]
+    public void OrdersSchema_NewOrderEncodeDecodeWithGroups()
+    {
+        // Test the orders schema message with groups and varData
+        Span<byte> buffer = stackalloc byte[512];
+        ref var msg = ref MemoryMarshal.AsRef<Cross.Schema.Orders.V0.NewOrderData>(buffer);
+
+        msg.OrderId = 42;
+        msg.Quantity = 100;
+        msg.Side = Cross.Schema.Orders.V0.Side.Buy;
+        msg.Currency = Cross.Schema.Orders.V0.Currency.USD;
+
+        // Verify field values
+        Assert.Equal(42UL, msg.OrderId);
+        Assert.Equal(100U, msg.Quantity);
+        Assert.Equal(Cross.Schema.Orders.V0.Side.Buy, msg.Side);
+        Assert.Equal(Cross.Schema.Orders.V0.Currency.USD, msg.Currency);
+    }
+
+    [Fact]
+    public void SeparateSchemas_DecimalCompositeIsIndependent()
+    {
+        // Both schemas define Decimal composite — verify both work independently
+        Assert.Equal(
+            Unsafe.SizeOf<Cross.Schema.Common.V0.Decimal>(),
+            Unsafe.SizeOf<Cross.Schema.Orders.V0.Decimal>());
+
+        // Different types
+        Assert.NotEqual(
+            typeof(Cross.Schema.Common.V0.Decimal),
+            typeof(Cross.Schema.Orders.V0.Decimal));
+    }
+
+    [Fact]
+    public void SeparateSchemas_GroupSizeEncodingIsIndependent()
+    {
+        // Both define GroupSizeEncoding — verify independent
+        Assert.Equal(
+            Cross.Schema.Common.V0.GroupSizeEncoding.MESSAGE_SIZE,
+            Cross.Schema.Orders.V0.GroupSizeEncoding.MESSAGE_SIZE);
+
+        Assert.NotEqual(
+            typeof(Cross.Schema.Common.V0.GroupSizeEncoding),
+            typeof(Cross.Schema.Orders.V0.GroupSizeEncoding));
+    }
+
+    [Fact]
+    public void CrossSchemaInterop_CanUseTypesFromBothSchemas()
+    {
+        // Simulate a scenario where application code uses types from both schemas
+        Span<byte> heartbeatBuffer = stackalloc byte[Cross.Schema.Common.V0.HeartbeatData.MESSAGE_SIZE];
+        Span<byte> orderBuffer = stackalloc byte[Cross.Schema.Orders.V0.NewOrderData.MESSAGE_SIZE];
+
+        ref var heartbeat = ref MemoryMarshal.AsRef<Cross.Schema.Common.V0.HeartbeatData>(heartbeatBuffer);
+        ref var order = ref MemoryMarshal.AsRef<Cross.Schema.Orders.V0.NewOrderData>(orderBuffer);
+
+        heartbeat.Timestamp = 100;
+        order.OrderId = 200;
+
+        // Parse both independently
+        var s1 = Cross.Schema.Common.V0.HeartbeatData.TryParse(
+            heartbeatBuffer,
+            Cross.Schema.Common.V0.HeartbeatData.MESSAGE_SIZE,
+            out var parsedHb, out _);
+
+        var s2 = Cross.Schema.Orders.V0.NewOrderData.TryParse(
+            orderBuffer,
+            Cross.Schema.Orders.V0.NewOrderData.MESSAGE_SIZE,
+            out var parsedOrder, out _);
+
+        Assert.True(s1);
+        Assert.True(s2);
+        Assert.Equal(100UL, parsedHb.Timestamp);
+        Assert.Equal(200UL, parsedOrder.OrderId);
+    }
+}

--- a/tests/SbeCodeGenerator.IntegrationTests/EdgeCaseIntegrationTests.cs
+++ b/tests/SbeCodeGenerator.IntegrationTests/EdgeCaseIntegrationTests.cs
@@ -232,7 +232,7 @@ namespace SbeCodeGenerator.IntegrationTests
             Assert.Equal(21, TextMessageData.MESSAGE_ID);
         }
 
-        [Fact(Skip = "Known issue: groups with 0 fixed fields have sizeof(T)=1 vs blockLength=0 mismatch")]
+        [Fact]
         public void TextMessage_ConsumeVariableLength_WithDataOnlyGroup()
         {
             var buffer = new byte[512];

--- a/tests/SbeCodeGenerator.IntegrationTests/EdgeCaseIntegrationTests.cs
+++ b/tests/SbeCodeGenerator.IntegrationTests/EdgeCaseIntegrationTests.cs
@@ -1,0 +1,281 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using Edge.Cases.Test.V0;
+using Xunit;
+
+namespace SbeCodeGenerator.IntegrationTests
+{
+    public class EdgeCaseIntegrationTests
+    {
+        // --- Sparse Enum Tests ---
+
+        [Fact]
+        public void StatusCode_HasCorrectSparseValues()
+        {
+            Assert.Equal((byte)0, (byte)StatusCode.New);
+            Assert.Equal((byte)3, (byte)StatusCode.PartiallyFilled);
+            Assert.Equal((byte)5, (byte)StatusCode.Filled);
+            Assert.Equal((byte)10, (byte)StatusCode.Cancelled);
+            Assert.Equal((byte)99, (byte)StatusCode.Rejected);
+        }
+
+        [Fact]
+        public void Venue_HasCorrectSparseValues()
+        {
+            Assert.Equal((byte)1, (byte)Venue.Nyse);
+            Assert.Equal((byte)2, (byte)Venue.Nasdaq);
+            Assert.Equal((byte)10, (byte)Venue.Bats);
+            Assert.Equal((byte)50, (byte)Venue.Iex);
+        }
+
+        [Fact]
+        public void StatusCode_RoundTrips_ThroughByte()
+        {
+            byte raw = 99;
+            var status = (StatusCode)raw;
+            Assert.Equal(StatusCode.Rejected, status);
+        }
+
+        // --- Large Set (uint16) Tests ---
+
+        [Fact]
+        public void TradingFlags_IsUInt16Based()
+        {
+            Assert.Equal(2, sizeof(TradingFlags));
+        }
+
+        [Fact]
+        public void TradingFlags_HighBitChoices_Work()
+        {
+            var flags = TradingFlags.Negotiated | TradingFlags.OffExchange;
+            Assert.True((flags & TradingFlags.Negotiated) != 0);
+            Assert.True((flags & TradingFlags.OffExchange) != 0);
+            Assert.True((flags & TradingFlags.Regular) == 0);
+
+            // Verify high bit values (>8 bits)
+            Assert.Equal((ushort)256, (ushort)TradingFlags.Negotiated);
+            Assert.Equal((ushort)512, (ushort)TradingFlags.OffExchange);
+        }
+
+        [Fact]
+        public void TradingFlags_AllChoices_Combine()
+        {
+            var all = TradingFlags.Regular | TradingFlags.OddLot | TradingFlags.DarkPool
+                    | TradingFlags.BlockTrade | TradingFlags.CrossTrade | TradingFlags.PreMarket
+                    | TradingFlags.AfterHours | TradingFlags.Auction | TradingFlags.Negotiated
+                    | TradingFlags.OffExchange;
+            Assert.Equal((ushort)0x3FF, (ushort)all); // 10 bits set = 1023
+        }
+
+        // --- Composite with Ref Tests ---
+
+        [Fact]
+        public void Instrument_HasCorrectMessageSize()
+        {
+            // int64(8) + IsinCode InlineArray(12) = 20
+            Assert.Equal(20, Instrument.MESSAGE_SIZE);
+        }
+
+        [Fact]
+        public void Instrument_TryParse_WithIsinRef()
+        {
+            Span<byte> buffer = stackalloc byte[Instrument.MESSAGE_SIZE];
+            ref var inst = ref MemoryMarshal.AsRef<Instrument>(buffer);
+            inst.InstrumentId = 12345;
+
+            // Write ISIN code into the Isin field
+            var isinBytes = Encoding.Latin1.GetBytes("US0378331005");
+            isinBytes.CopyTo(MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref inst.Isin, 1)).Slice(0, 12));
+
+            Assert.True(Instrument.TryParse(buffer, out var parsed, out _));
+            Assert.Equal(12345L, parsed.InstrumentId);
+            Assert.Equal("US0378331005", parsed.Isin.ToString());
+        }
+
+        // --- DecimalEncoding (constant exponent) Tests ---
+
+        [Fact]
+        public void DecimalEncoding_HasConstantExponent()
+        {
+            Assert.Equal((sbyte)-7, DecimalEncoding.Exponent);
+        }
+
+        [Fact]
+        public void DecimalEncoding_MessageSize_ExcludesConstant()
+        {
+            // Only mantissa (int64 = 8), exponent is constant
+            Assert.Equal(8, DecimalEncoding.MESSAGE_SIZE);
+        }
+
+        [Fact]
+        public void DecimalEncoding_RoundTrip()
+        {
+            Span<byte> buffer = stackalloc byte[DecimalEncoding.MESSAGE_SIZE];
+            ref var dec = ref MemoryMarshal.AsRef<DecimalEncoding>(buffer);
+            dec.Mantissa = 12345678900L;
+
+            Assert.True(DecimalEncoding.TryParse(buffer, out var parsed, out _));
+            Assert.Equal(12345678900L, parsed.Mantissa);
+        }
+
+        // --- Multiple Types Blocks ---
+
+        [Fact]
+        public void Venue_FromSecondTypesBlock_IsAccessible()
+        {
+            // Venue enum is defined in the second <types> block
+            Assert.Equal(Venue.Iex, (Venue)50);
+        }
+
+        // --- Trade Message (composite refs, sparse enum, large set) ---
+
+        [Fact]
+        public unsafe void Trade_HasCorrectMessageSize()
+        {
+            // int64(8) + Instrument(20) + DecimalEncoding(8) + int64(8) + StatusCode(1) + TradingFlags(2) + Venue(1) = 48
+            Assert.Equal(48, TradeData.MESSAGE_SIZE);
+            Assert.Equal(TradeData.MESSAGE_SIZE, sizeof(TradeData));
+        }
+
+        [Fact]
+        public void Trade_FixedFieldsRoundTrip()
+        {
+            Span<byte> buffer = stackalloc byte[TradeData.MESSAGE_SIZE];
+            ref var trade = ref MemoryMarshal.AsRef<TradeData>(buffer);
+
+            trade.TradeId = 999L;
+            trade.Instrument.InstrumentId = 42L;
+            trade.Price.Mantissa = 15000000L;
+            trade.Quantity = 100L;
+            trade.Status = StatusCode.Filled;
+            trade.Flags = TradingFlags.Regular | TradingFlags.DarkPool;
+            trade.Venue = Venue.Nasdaq;
+
+            Assert.True(TradeData.TryParse(buffer, out var parsed, out _));
+            Assert.Equal(999L, parsed.TradeId);
+            Assert.Equal(42L, parsed.Instrument.InstrumentId);
+            Assert.Equal(15000000L, parsed.Price.Mantissa);
+            Assert.Equal(100L, parsed.Quantity);
+            Assert.Equal(StatusCode.Filled, parsed.Status);
+            Assert.True((parsed.Flags & TradingFlags.DarkPool) != 0);
+            Assert.Equal(Venue.Nasdaq, parsed.Venue);
+        }
+
+        [Fact]
+        public void Trade_TryEncode_Works()
+        {
+            TradeData trade = default;
+            trade.TradeId = 1L;
+            trade.Quantity = 50L;
+            trade.Status = StatusCode.New;
+            trade.Venue = Venue.Nyse;
+
+            Span<byte> buffer = stackalloc byte[TradeData.MESSAGE_SIZE];
+            Assert.True(trade.TryEncode(buffer, out int bytesWritten));
+            Assert.Equal(TradeData.MESSAGE_SIZE, bytesWritten);
+        }
+
+        [Fact]
+        public void Trade_ToString_IncludesFields()
+        {
+            TradeData trade = default;
+            trade.TradeId = 42L;
+            trade.Status = StatusCode.Cancelled;
+            var str = trade.ToString();
+            Assert.Contains("TradeId", str);
+            Assert.Contains("42", str);
+        }
+
+        [Fact]
+        public void Trade_WriteHeader_PopulatesCorrectly()
+        {
+            Span<byte> buffer = stackalloc byte[MessageHeader.MESSAGE_SIZE + TradeData.MESSAGE_SIZE];
+            var headerSize = TradeData.WriteHeader(buffer);
+            ref var header = ref MemoryMarshal.AsRef<MessageHeader>(buffer);
+
+            Assert.Equal(MessageHeader.MESSAGE_SIZE, headerSize);
+            Assert.Equal((ushort)TradeData.MESSAGE_SIZE, header.BlockLength);
+            Assert.Equal((ushort)TradeData.MESSAGE_ID, header.TemplateId);
+        }
+
+        // --- MarketData Message (large set + sparse enum together) ---
+
+        [Fact]
+        public void MarketData_RoundTrip()
+        {
+            Span<byte> buffer = stackalloc byte[MarketDataData.MESSAGE_SIZE];
+            ref var md = ref MemoryMarshal.AsRef<MarketDataData>(buffer);
+
+            md.SymbolId = 12345;
+            md.Flags = TradingFlags.PreMarket | TradingFlags.Auction | TradingFlags.OffExchange;
+            md.Status = StatusCode.PartiallyFilled;
+            md.Venue = Venue.Bats;
+
+            Assert.True(MarketDataData.TryParse(buffer, out var parsed, out _));
+            Assert.Equal(12345, parsed.SymbolId);
+            Assert.True((parsed.Flags & TradingFlags.PreMarket) != 0);
+            Assert.True((parsed.Flags & TradingFlags.OffExchange) != 0);
+            Assert.True((parsed.Flags & TradingFlags.Regular) == 0);
+            Assert.Equal(StatusCode.PartiallyFilled, parsed.Status);
+            Assert.Equal(Venue.Bats, parsed.Venue);
+        }
+
+        // --- TextMessage (group with only data, no fixed fields) ---
+
+        [Fact]
+        public void TextMessage_GroupWithOnlyData_Compiles()
+        {
+            // TextMessage has a group "attachments" with only <data> (no fixed fields)
+            // Verifying the generated code compiles and basic structure works
+            Assert.True(TextMessageData.MESSAGE_SIZE > 0);
+            Assert.Equal(21, TextMessageData.MESSAGE_ID);
+        }
+
+        [Fact(Skip = "Known issue: groups with 0 fixed fields have sizeof(T)=1 vs blockLength=0 mismatch")]
+        public void TextMessage_ConsumeVariableLength_WithDataOnlyGroup()
+        {
+            var buffer = new byte[512];
+            var span = buffer.AsSpan();
+            int offset = 0;
+
+            // Write TextMessage fixed fields
+            ref TextMessageData msg = ref MemoryMarshal.AsRef<TextMessageData>(span);
+            msg.MessageId = 42L;
+            offset += TextMessageData.MESSAGE_SIZE;
+
+            // attachments group: 1 entry (group has no fixed fields, only data)
+            ref var groupHeader = ref MemoryMarshal.AsRef<GroupSizeEncoding>(span.Slice(offset));
+            groupHeader.BlockLength = 0; // no fixed fields
+            groupHeader.NumInGroup = 1;
+            offset += GroupSizeEncoding.MESSAGE_SIZE;
+
+            // content data for the attachment (VarStringEncoding: uint32 length + data)
+            var contentBytes = Encoding.UTF8.GetBytes("Hello World");
+            BitConverter.TryWriteBytes(span.Slice(offset, 4), (uint)contentBytes.Length);
+            contentBytes.CopyTo(span.Slice(offset + 4));
+            offset += 4 + contentBytes.Length;
+
+            // body data (message-level VarStringEncoding)
+            var bodyBytes = Encoding.UTF8.GetBytes("Message body");
+            BitConverter.TryWriteBytes(span.Slice(offset, 4), (uint)bodyBytes.Length);
+            bodyBytes.CopyTo(span.Slice(offset + 4));
+            offset += 4 + bodyBytes.Length;
+
+            // Parse
+            string capturedContent = "";
+            string capturedBody = "";
+            var reader = new Edge.Cases.Test.V0.Runtime.SpanReader(span.Slice(TextMessageData.MESSAGE_SIZE, offset - TextMessageData.MESSAGE_SIZE));
+            var parsed = new TextMessageData();
+            parsed.ConsumeVariableLengthSegments(
+                ref reader,
+                attachments => { },
+                attachmentContent => { capturedContent = Encoding.UTF8.GetString(attachmentContent.VarData); },
+                body => { capturedBody = Encoding.UTF8.GetString(body.VarData); }
+            );
+
+            Assert.Equal("Hello World", capturedContent);
+            Assert.Equal("Message body", capturedBody);
+        }
+    }
+}

--- a/tests/SbeCodeGenerator.IntegrationTests/EdgeCaseIntegrationTests.cs
+++ b/tests/SbeCodeGenerator.IntegrationTests/EdgeCaseIntegrationTests.cs
@@ -269,7 +269,7 @@ namespace SbeCodeGenerator.IntegrationTests
             var parsed = new TextMessageData();
             parsed.ConsumeVariableLengthSegments(
                 ref reader,
-                attachments => { },
+                (in TextMessageData.AttachmentsData attachments) => { },
                 attachmentContent => { capturedContent = Encoding.UTF8.GetString(attachmentContent.VarData); },
                 body => { capturedBody = Encoding.UTF8.GetString(body.VarData); }
             );

--- a/tests/SbeCodeGenerator.IntegrationTests/FluentEncoderIntegrationTests.cs
+++ b/tests/SbeCodeGenerator.IntegrationTests/FluentEncoderIntegrationTests.cs
@@ -56,8 +56,8 @@ namespace SbeCodeGenerator.IntegrationTests
 
             decoded.ConsumeVariableLengthSegments(
                 variableData,
-                bid => decodedBids.Add(bid),
-                ask => decodedAsks.Add(ask)
+                (in Integration.Test.V0.OrderBookData.BidsData bid) => decodedBids.Add(bid),
+                (in Integration.Test.V0.OrderBookData.AsksData ask) => decodedAsks.Add(ask)
             );
 
             Assert.Equal(2, decodedBids.Count);
@@ -193,8 +193,8 @@ namespace SbeCodeGenerator.IntegrationTests
             var askCount = 0;
             decoded.ConsumeVariableLengthSegments(
                 variableData,
-                bid => bidCount++,
-                ask => askCount++
+                (in Integration.Test.V0.OrderBookData.BidsData bid) => bidCount++,
+                (in Integration.Test.V0.OrderBookData.AsksData ask) => askCount++
             );
 
             Assert.Equal(3, bidCount);
@@ -252,8 +252,8 @@ namespace SbeCodeGenerator.IntegrationTests
 
             decoded.ConsumeVariableLengthSegments(
                 variableData,
-                bid => decodedBids.Add(bid),
-                ask => decodedAsks.Add(ask)
+                (in Integration.Test.V0.OrderBookData.BidsData bid) => decodedBids.Add(bid),
+                (in Integration.Test.V0.OrderBookData.AsksData ask) => decodedAsks.Add(ask)
             );
 
             Assert.Equal(3, decodedBids.Count);

--- a/tests/SbeCodeGenerator.IntegrationTests/GeneratorIntegrationTests.cs
+++ b/tests/SbeCodeGenerator.IntegrationTests/GeneratorIntegrationTests.cs
@@ -420,8 +420,8 @@ namespace SbeCodeGenerator.IntegrationTests
             var orderBook = new Integration.Test.V0.OrderBookData();
             orderBook.ConsumeVariableLengthSegments(
                 buffer.Slice(0, offset),
-                bid => { bidPrices.Add(bid.Price.Value); bidQuantities.Add(bid.Quantity); },
-                ask => { askPrices.Add(ask.Price.Value); askQuantities.Add(ask.Quantity); }
+                (in Integration.Test.V0.OrderBookData.BidsData bid) => { bidPrices.Add(bid.Price.Value); bidQuantities.Add(bid.Quantity); },
+                (in Integration.Test.V0.OrderBookData.AsksData ask) => { askPrices.Add(ask.Price.Value); askQuantities.Add(ask.Quantity); }
             );
             
             // Assert
@@ -590,20 +590,27 @@ namespace SbeCodeGenerator.IntegrationTests
         [Fact]
         public void TryParse_WithSpanReader_FailsWhenInsufficientBufferForMessage()
         {
-            // Test that TryParse fails when buffer is smaller than MESSAGE_SIZE
-            // This validates the TryRead check in SpanReader
+            // Test that TryParse fails when buffer is smaller than blockLength
+            // This validates the TryReadBlock check in SpanReader
             
-            // Arrange
-            int blockLength = 10; // Less than MESSAGE_SIZE
-            Span<byte> buffer = stackalloc byte[10]; // Same as blockLength, but less than MESSAGE_SIZE
+            // Arrange - blockLength larger than available buffer
+            int blockLength = 20;
+            Span<byte> buffer = stackalloc byte[10]; // Less than blockLength
             
             // Act
             var success = Integration.Test.V0.NewOrderData.TryParse(buffer, blockLength, out var message, out var variableData);
             
-            // Assert
+            // Assert - should fail because buffer is too small for blockLength
             Assert.False(success);
             Assert.Equal(default(Integration.Test.V0.NewOrderData), message);
             Assert.True(variableData.IsEmpty);
+            
+            // Verify that blockLength < MESSAGE_SIZE succeeds (backward compat: partial read)
+            int smallBlockLength = 10;
+            Span<byte> adequateBuffer = stackalloc byte[10];
+            var partialSuccess = Integration.Test.V0.NewOrderData.TryParse(adequateBuffer, smallBlockLength, out var partialMessage, out var remaining);
+            Assert.True(partialSuccess);
+            Assert.True(remaining.IsEmpty); // All 10 bytes consumed by blockLength
         }
 
         [Fact]
@@ -659,8 +666,8 @@ namespace SbeCodeGenerator.IntegrationTests
             var orderBook = new Integration.Test.V0.OrderBookData();
             orderBook.ConsumeVariableLengthSegments(
                 ref reader,
-                bid => { bidPrices.Add(bid.Price.Value); bidQuantities.Add(bid.Quantity); },
-                ask => { askPrices.Add(ask.Price.Value); askQuantities.Add(ask.Quantity); }
+                (in Integration.Test.V0.OrderBookData.BidsData bid) => { bidPrices.Add(bid.Price.Value); bidQuantities.Add(bid.Quantity); },
+                (in Integration.Test.V0.OrderBookData.AsksData ask) => { askPrices.Add(ask.Price.Value); askQuantities.Add(ask.Quantity); }
             );
             
             // Assert - Verify parsed data

--- a/tests/SbeCodeGenerator.IntegrationTests/GroupAndVarDataEncodingTests.cs
+++ b/tests/SbeCodeGenerator.IntegrationTests/GroupAndVarDataEncodingTests.cs
@@ -78,8 +78,8 @@ namespace SbeCodeGenerator.IntegrationTests
             
             decoded.ConsumeVariableLengthSegments(
                 variableData,
-                bid => decodedBids.Add(bid),
-                ask => decodedAsks.Add(ask)
+                (in Integration.Test.V0.OrderBookData.BidsData bid) => decodedBids.Add(bid),
+                (in Integration.Test.V0.OrderBookData.AsksData ask) => decodedAsks.Add(ask)
             );
             
             Assert.Equal(2, decodedBids.Count);
@@ -288,8 +288,8 @@ namespace SbeCodeGenerator.IntegrationTests
 
             decodedMessage.ConsumeVariableLengthSegments(
                 variableData,
-                bid => decodedBids.Add(bid),
-                ask => decodedAsks.Add(ask)
+                (in Integration.Test.V0.OrderBookData.BidsData bid) => decodedBids.Add(bid),
+                (in Integration.Test.V0.OrderBookData.AsksData ask) => decodedAsks.Add(ask)
             );
 
             // Assert - Verify all data matches

--- a/tests/SbeCodeGenerator.IntegrationTests/TestSchemas/cross-schema-common.xml
+++ b/tests/SbeCodeGenerator.IntegrationTests/TestSchemas/cross-schema-common.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
+                   package="cross_schema.common"
+                   id="100"
+                   version="0"
+                   semanticVersion="1.0"
+                   description="Common types shared across schemas"
+                   byteOrder="littleEndian">
+    <types>
+        <composite name="MessageHeader" description="Standard message header">
+            <type name="blockLength" primitiveType="uint16"/>
+            <type name="templateId" primitiveType="uint16"/>
+            <type name="schemaId" primitiveType="uint16"/>
+            <type name="version" primitiveType="uint16"/>
+        </composite>
+
+        <composite name="GroupSizeEncoding" description="Repeating group dimensions">
+            <type name="blockLength" primitiveType="uint16"/>
+            <type name="numInGroup" primitiveType="uint32" maxValue="2147483647"/>
+        </composite>
+
+        <composite name="VarStringEncoding" description="Variable-length string encoding">
+            <type name="length" primitiveType="uint32" maxValue="1073741824"/>
+            <type name="varData" primitiveType="uint8" length="0" characterEncoding="UTF-8"/>
+        </composite>
+
+        <enum name="Currency" encodingType="uint8">
+            <validValue name="USD">0</validValue>
+            <validValue name="EUR">1</validValue>
+            <validValue name="GBP">2</validValue>
+            <validValue name="JPY">3</validValue>
+        </enum>
+
+        <composite name="Decimal" description="Fixed-point decimal">
+            <type name="mantissa" primitiveType="int64"/>
+            <type name="exponent" primitiveType="int8" presence="constant">-3</type>
+        </composite>
+    </types>
+
+    <sbe:message name="Heartbeat" id="1" description="Heartbeat message">
+        <field name="Timestamp" id="1" type="uint64" description="Epoch timestamp in nanoseconds"/>
+    </sbe:message>
+</sbe:messageSchema>

--- a/tests/SbeCodeGenerator.IntegrationTests/TestSchemas/cross-schema-orders.xml
+++ b/tests/SbeCodeGenerator.IntegrationTests/TestSchemas/cross-schema-orders.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
+                   package="cross_schema.orders"
+                   id="101"
+                   version="0"
+                   semanticVersion="1.0"
+                   description="Order schema that redefines common types"
+                   byteOrder="littleEndian">
+    <types>
+        <composite name="MessageHeader" description="Standard message header">
+            <type name="blockLength" primitiveType="uint16"/>
+            <type name="templateId" primitiveType="uint16"/>
+            <type name="schemaId" primitiveType="uint16"/>
+            <type name="version" primitiveType="uint16"/>
+        </composite>
+
+        <composite name="GroupSizeEncoding" description="Repeating group dimensions">
+            <type name="blockLength" primitiveType="uint16"/>
+            <type name="numInGroup" primitiveType="uint32" maxValue="2147483647"/>
+        </composite>
+
+        <composite name="VarStringEncoding" description="Variable-length string encoding">
+            <type name="length" primitiveType="uint32" maxValue="1073741824"/>
+            <type name="varData" primitiveType="uint8" length="0" characterEncoding="UTF-8"/>
+        </composite>
+
+        <enum name="Side" encodingType="uint8">
+            <validValue name="Buy">0</validValue>
+            <validValue name="Sell">1</validValue>
+        </enum>
+
+        <enum name="Currency" encodingType="uint8">
+            <validValue name="USD">0</validValue>
+            <validValue name="EUR">1</validValue>
+            <validValue name="GBP">2</validValue>
+            <validValue name="JPY">3</validValue>
+        </enum>
+
+        <composite name="Decimal" description="Fixed-point decimal">
+            <type name="mantissa" primitiveType="int64"/>
+            <type name="exponent" primitiveType="int8" presence="constant">-3</type>
+        </composite>
+    </types>
+
+    <sbe:message name="NewOrder" id="1" description="New order message">
+        <field name="OrderId" id="1" type="uint64" description="Order identifier"/>
+        <field name="Price" id="2" type="Decimal" description="Order price"/>
+        <field name="Quantity" id="3" type="uint32" description="Order quantity"/>
+        <field name="Side" id="4" type="Side" description="Buy or Sell"/>
+        <field name="Currency" id="5" type="Currency" description="Currency"/>
+        <group name="Legs" id="6" description="Multi-leg order legs">
+            <field name="LegSymbol" id="7" type="uint32" description="Leg symbol ID"/>
+            <field name="LegSide" id="8" type="Side" description="Leg side"/>
+            <field name="LegRatio" id="9" type="uint32" description="Leg ratio"/>
+        </group>
+        <data name="ClientOrderId" id="10" type="VarStringEncoding" description="Client order ID"/>
+    </sbe:message>
+</sbe:messageSchema>

--- a/tests/SbeCodeGenerator.IntegrationTests/TestSchemas/edge-cases-schema.xml
+++ b/tests/SbeCodeGenerator.IntegrationTests/TestSchemas/edge-cases-schema.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
+                   package="edge_cases_test"
+                   id="5"
+                   version="0"
+                   semanticVersion="1.0"
+                   description="Edge cases test schema"
+                   byteOrder="littleEndian">
+
+    <!-- First types block -->
+    <types>
+        <composite name="MessageHeader" description="Template ID and length of message root">
+            <type name="blockLength" primitiveType="uint16"/>
+            <type name="templateId" primitiveType="uint16"/>
+            <type name="schemaId" primitiveType="uint16"/>
+            <type name="version" primitiveType="uint16"/>
+        </composite>
+
+        <composite name="GroupSizeEncoding" description="Repeating group dimensions.">
+            <type name="blockLength" primitiveType="uint16"/>
+            <type name="numInGroup" primitiveType="uint16"/>
+        </composite>
+
+        <composite name="VarStringEncoding" description="Variable length UTF-8 string.">
+            <type name="length" primitiveType="uint32" maxValue="1073741824"/>
+            <type name="varData" length="0" primitiveType="uint8" characterEncoding="UTF-8"/>
+        </composite>
+
+        <!-- Composite with ref fields -->
+        <type name="isinCode" primitiveType="char" length="12" characterEncoding="UTF-8"/>
+
+        <composite name="Instrument" description="Instrument composite with ref">
+            <type name="instrumentId" primitiveType="int64"/>
+            <ref name="isin" type="isinCode"/>
+        </composite>
+
+        <!-- Enum with sparse (non-sequential) values -->
+        <enum name="StatusCode" encodingType="uint8">
+            <validValue name="new">0</validValue>
+            <validValue name="partiallyFilled">3</validValue>
+            <validValue name="filled">5</validValue>
+            <validValue name="cancelled">10</validValue>
+            <validValue name="rejected">99</validValue>
+        </enum>
+
+        <!-- Set with uint16 encoding (>8 bits) -->
+        <set name="TradingFlags" encodingType="uint16">
+            <choice name="regular">0</choice>
+            <choice name="oddLot">1</choice>
+            <choice name="darkPool">2</choice>
+            <choice name="blockTrade">3</choice>
+            <choice name="crossTrade">4</choice>
+            <choice name="preMarket">5</choice>
+            <choice name="afterHours">6</choice>
+            <choice name="auction">7</choice>
+            <choice name="negotiated">8</choice>
+            <choice name="offExchange">9</choice>
+        </set>
+    </types>
+
+    <!-- Second types block (tests multiple types blocks) -->
+    <types>
+        <enum name="Venue" encodingType="uint8">
+            <validValue name="nyse">1</validValue>
+            <validValue name="nasdaq">2</validValue>
+            <validValue name="bats">10</validValue>
+            <validValue name="iex">50</validValue>
+        </enum>
+
+        <!-- Constant with valueRef -->
+        <composite name="DecimalEncoding" description="Decimal encoding with constant exponent">
+            <type name="mantissa" primitiveType="int64"/>
+            <type name="exponent" primitiveType="int8" presence="constant">-7</type>
+        </composite>
+    </types>
+
+    <!-- Message with composite ref fields -->
+    <sbe:message name="Trade" id="20" description="Trade with composite ref">
+        <field name="tradeId" id="1" type="int64"/>
+        <field name="instrument" id="2" type="Instrument"/>
+        <field name="price" id="3" type="DecimalEncoding"/>
+        <field name="quantity" id="4" type="int64"/>
+        <field name="status" id="5" type="StatusCode"/>
+        <field name="flags" id="6" type="TradingFlags"/>
+        <field name="venue" id="7" type="Venue"/>
+    </sbe:message>
+
+    <!-- Message with group that has only data fields (no fixed fields) -->
+    <sbe:message name="TextMessage" id="21" description="Message with data-only group">
+        <field name="messageId" id="1" type="int64"/>
+        <group name="attachments" id="2" dimensionType="GroupSizeEncoding">
+            <data name="content" id="3" type="VarStringEncoding"/>
+        </group>
+        <data name="body" id="4" type="VarStringEncoding"/>
+    </sbe:message>
+
+    <!-- Message with large set and sparse enum -->
+    <sbe:message name="MarketData" id="22" description="Market data with large set">
+        <field name="symbolId" id="1" type="int32"/>
+        <field name="flags" id="2" type="TradingFlags"/>
+        <field name="status" id="3" type="StatusCode"/>
+        <field name="venue" id="4" type="Venue"/>
+    </sbe:message>
+
+</sbe:messageSchema>

--- a/tests/SbeCodeGenerator.Tests/MessagesCodeGeneratorTests.cs
+++ b/tests/SbeCodeGenerator.Tests/MessagesCodeGeneratorTests.cs
@@ -539,12 +539,15 @@ namespace SbeCodeGenerator.Tests
             var msgResult = results.FirstOrDefault(r => r.name.Contains("CarMessage"));
             Assert.NotEqual(default, msgResult);
 
-            // Top-level group callback: Action<PerformanceFiguresData>
-            Assert.Contains("Action<PerformanceFiguresData> callbackPerformanceFigures", msgResult.content);
-            // Nested group callback should include parent as context: Action<PerformanceFiguresData, AccelerationData>
-            Assert.Contains("Action<PerformanceFiguresData, AccelerationData> callbackAcceleration", msgResult.content);
-            // Nested callback invocation should pass parent data
-            Assert.Contains("callbackAcceleration(data, nestedData)", msgResult.content);
+            // Top-level group callback: custom delegate with in
+            Assert.Contains("PerformanceFiguresHandler callbackPerformanceFigures", msgResult.content);
+            // Nested group callback should include parent as context
+            Assert.Contains("AccelerationHandler callbackAcceleration", msgResult.content);
+            // Delegate types with in parameters
+            Assert.Contains("public delegate void PerformanceFiguresHandler(in PerformanceFiguresData data)", msgResult.content);
+            Assert.Contains("public delegate void AccelerationHandler(in PerformanceFiguresData performanceFiguresData, in AccelerationData data)", msgResult.content);
+            // Nested callback invocation should pass parent data with in
+            Assert.Contains("callbackAcceleration(in data, in nestedData)", msgResult.content);
         }
 
         [Fact]

--- a/tests/SbeCodeGenerator.Tests/MessagesCodeGeneratorTests.cs
+++ b/tests/SbeCodeGenerator.Tests/MessagesCodeGeneratorTests.cs
@@ -594,7 +594,7 @@ namespace SbeCodeGenerator.Tests
             var msgResult = results.First(r => r.name.Contains("Order"));
 
             // Assert
-            Assert.Contains("public override string ToString()", msgResult.content);
+            Assert.Contains("public readonly override string ToString()", msgResult.content);
             Assert.Contains("OrderData {{ OrderId={OrderId}, Price={Price}, Quantity={Quantity} }}", msgResult.content);
         }
 

--- a/tests/SbeCodeGenerator.Tests/MessagesCodeGeneratorTests.cs
+++ b/tests/SbeCodeGenerator.Tests/MessagesCodeGeneratorTests.cs
@@ -547,7 +547,7 @@ namespace SbeCodeGenerator.Tests
             Assert.Contains("public delegate void PerformanceFiguresHandler(in PerformanceFiguresData data)", msgResult.content);
             Assert.Contains("public delegate void AccelerationHandler(in PerformanceFiguresData performanceFiguresData, in AccelerationData data)", msgResult.content);
             // Nested callback invocation should pass parent data with in
-            Assert.Contains("callbackAcceleration(in data, in nestedData)", msgResult.content);
+            Assert.Contains("callbackAcceleration(in data, in nestedData1)", msgResult.content);
         }
 
         [Fact]

--- a/tests/SbeCodeGenerator.Tests/Snapshots/MessagesCodeGenerator.Message.Quote.verified.txt
+++ b/tests/SbeCodeGenerator.Tests/Snapshots/MessagesCodeGenerator.Message.Quote.verified.txt
@@ -118,7 +118,7 @@ public partial struct QuoteData
 		return bytesWritten;
 	}
 	/// <summary>Returns a string representation of this struct for debugging.</summary>
-	public override string ToString() => $"QuoteData {{ BidPrice={BidPrice}, BidQuantity={BidQuantity}, AskPrice={AskPrice}, AskQuantity={AskQuantity} }}";
+	public readonly override string ToString() => $"QuoteData {{ BidPrice={BidPrice}, BidQuantity={BidQuantity}, AskPrice={AskPrice}, AskQuantity={AskQuantity} }}";
 	/// <summary>
 	/// Writes a pre-populated MessageHeader for this message type to the destination buffer.
 	/// Sets BlockLength=BLOCK_LENGTH, TemplateId=2, SchemaId=1, Version=0.

--- a/tests/SbeCodeGenerator.Tests/Snapshots/MessagesCodeGenerator.Message.Quote.verified.txt
+++ b/tests/SbeCodeGenerator.Tests/Snapshots/MessagesCodeGenerator.Message.Quote.verified.txt
@@ -2,6 +2,7 @@
 using TestNamespace.V0.Runtime;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices;
 namespace TestNamespace.V0;
 /// <summary>
 /// Quote message (Version 0)
@@ -58,54 +59,18 @@ public partial struct QuoteData
 	public static bool TryParse(ReadOnlySpan<byte> buffer, int blockLength, out QuoteData message, out ReadOnlySpan<byte> variableData)
 	{
 		var reader = new SpanReader(buffer);
-		// Read the message data
-		if (!reader.TryRead<QuoteData>(out message))
+		if (!reader.TryReadBlock<QuoteData>(blockLength, out message))
 		{
 			variableData = default;
 			return false;
 		}
-		
-		// Handle schema evolution: skip additional bytes if blockLength > MESSAGE_SIZE
-		var additionalBytes = blockLength - MESSAGE_SIZE;
-		if (additionalBytes > 0)
-		{
-			if (!reader.TrySkip(additionalBytes))
-			{
-				variableData = default;
-				return false;
-			}
-			variableData = reader.Remaining;
-		}
-		else
-		{
-			// For backward compatibility: variable data starts at blockLength
-			if (blockLength > buffer.Length)
-			{
-				variableData = default;
-				return false;
-			}
-			variableData = buffer.Slice(blockLength);
-		}
-		
+		variableData = reader.Remaining;
 		return true;
 	}
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public static bool TryParseWithReader(ref SpanReader reader, int blockLength, out QuoteData message)
 	{
-		// Read the message data
-		if (!reader.TryRead<QuoteData>(out message))
-		{
-			return false;
-		}
-		
-		// Handle schema evolution: skip additional bytes if blockLength > MESSAGE_SIZE
-		var additionalBytes = blockLength - MESSAGE_SIZE;
-		if (additionalBytes > 0 && !reader.TrySkip(additionalBytes))
-		{
-			return false;
-		}
-		
-		return true;
+		return reader.TryReadBlock<QuoteData>(blockLength, out message);
 	}
 	/// <summary>
 	/// Encodes this Quote message to the provided buffer.

--- a/tests/SbeCodeGenerator.Tests/Snapshots/MessagesCodeGenerator.Message.Trade.verified.txt
+++ b/tests/SbeCodeGenerator.Tests/Snapshots/MessagesCodeGenerator.Message.Trade.verified.txt
@@ -118,7 +118,7 @@ public partial struct TradeData
 		return bytesWritten;
 	}
 	/// <summary>Returns a string representation of this struct for debugging.</summary>
-	public override string ToString() => $"TradeData {{ TradeId={TradeId}, Price={Price}, Quantity={Quantity}, Side={Side} }}";
+	public readonly override string ToString() => $"TradeData {{ TradeId={TradeId}, Price={Price}, Quantity={Quantity}, Side={Side} }}";
 	/// <summary>
 	/// Writes a pre-populated MessageHeader for this message type to the destination buffer.
 	/// Sets BlockLength=BLOCK_LENGTH, TemplateId=1, SchemaId=1, Version=0.

--- a/tests/SbeCodeGenerator.Tests/Snapshots/MessagesCodeGenerator.Message.Trade.verified.txt
+++ b/tests/SbeCodeGenerator.Tests/Snapshots/MessagesCodeGenerator.Message.Trade.verified.txt
@@ -2,6 +2,7 @@
 using TestNamespace.V0.Runtime;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices;
 namespace TestNamespace.V0;
 /// <summary>
 /// Trade message (Version 0)
@@ -58,54 +59,18 @@ public partial struct TradeData
 	public static bool TryParse(ReadOnlySpan<byte> buffer, int blockLength, out TradeData message, out ReadOnlySpan<byte> variableData)
 	{
 		var reader = new SpanReader(buffer);
-		// Read the message data
-		if (!reader.TryRead<TradeData>(out message))
+		if (!reader.TryReadBlock<TradeData>(blockLength, out message))
 		{
 			variableData = default;
 			return false;
 		}
-		
-		// Handle schema evolution: skip additional bytes if blockLength > MESSAGE_SIZE
-		var additionalBytes = blockLength - MESSAGE_SIZE;
-		if (additionalBytes > 0)
-		{
-			if (!reader.TrySkip(additionalBytes))
-			{
-				variableData = default;
-				return false;
-			}
-			variableData = reader.Remaining;
-		}
-		else
-		{
-			// For backward compatibility: variable data starts at blockLength
-			if (blockLength > buffer.Length)
-			{
-				variableData = default;
-				return false;
-			}
-			variableData = buffer.Slice(blockLength);
-		}
-		
+		variableData = reader.Remaining;
 		return true;
 	}
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public static bool TryParseWithReader(ref SpanReader reader, int blockLength, out TradeData message)
 	{
-		// Read the message data
-		if (!reader.TryRead<TradeData>(out message))
-		{
-			return false;
-		}
-		
-		// Handle schema evolution: skip additional bytes if blockLength > MESSAGE_SIZE
-		var additionalBytes = blockLength - MESSAGE_SIZE;
-		if (additionalBytes > 0 && !reader.TrySkip(additionalBytes))
-		{
-			return false;
-		}
-		
-		return true;
+		return reader.TryReadBlock<TradeData>(blockLength, out message);
 	}
 	/// <summary>
 	/// Encodes this Trade message to the provided buffer.

--- a/tests/SbeCodeGenerator.Tests/Snapshots/TypesCodeGenerator.Composite.MessageHeader.verified.txt
+++ b/tests/SbeCodeGenerator.Tests/Snapshots/TypesCodeGenerator.Composite.MessageHeader.verified.txt
@@ -41,5 +41,5 @@ public partial struct MessageHeader
 	/// </summary>
 	public ushort Version;
 	/// <summary>Returns a string representation of this struct for debugging.</summary>
-	public override string ToString() => $"MessageHeader {{ BlockLength={BlockLength}, TemplateId={TemplateId}, SchemaId={SchemaId}, Version={Version} }}";
+	public readonly override string ToString() => $"MessageHeader {{ BlockLength={BlockLength}, TemplateId={TemplateId}, SchemaId={SchemaId}, Version={Version} }}";
 }

--- a/tests/SbeCodeGenerator.Tests/TypesCodeGeneratorTests.cs
+++ b/tests/SbeCodeGenerator.Tests/TypesCodeGeneratorTests.cs
@@ -89,6 +89,89 @@ namespace SbeCodeGenerator.Tests
         }
 
         [Fact]
+        public void Generate_WithCompositeCharArray_ProducesInlineArrayAndCorrectSize()
+        {
+            // Arrange
+            var generator = new TypesCodeGenerator();
+            var context = new SchemaContext("test-schema");
+            var schema = SchemaReader.Parse(@"
+                <messageSchema>
+                    <types>
+                        <composite name='engine' description='Engine composite'>
+                            <type name='capacity' primitiveType='uint16'/>
+                            <type name='numCylinders' primitiveType='uint8'/>
+                            <type name='manufacturerCode' primitiveType='char' length='3'/>
+                        </composite>
+                    </types>
+                </messageSchema>");
+
+            // Act
+            var results = generator.Generate("TestNamespace", schema, context, default(SourceProductionContext));
+            var resultList = results.ToList();
+
+            // Assert - InlineArray type generated for manufacturerCode
+            var charArrayType = resultList.FirstOrDefault(r => r.name.Contains("ManufacturerCode"));
+            Assert.NotEqual(default, charArrayType);
+            Assert.Contains("InlineArray(3)", charArrayType.content);
+
+            // Assert - Composite uses the InlineArray type as a field
+            var compositeResult = resultList.FirstOrDefault(r => r.name.Contains("Engine"));
+            Assert.NotEqual(default, compositeResult);
+            Assert.Contains("ManufacturerCode", compositeResult.content);
+
+            // Assert - MESSAGE_SIZE is correct: uint16(2) + uint8(1) + char[3](3) = 6
+            Assert.Contains("MESSAGE_SIZE = 6", compositeResult.content);
+        }
+
+        [Fact]
+        public void Generate_WithSet_NormalizesChoiceNames()
+        {
+            var generator = new TypesCodeGenerator();
+            var context = new SchemaContext("test-schema");
+            var schema = SchemaReader.Parse(@"
+                <messageSchema>
+                    <types>
+                        <set name='TestSet' encodingType='uint8'>
+                            <choice name='sunRoof'>0</choice>
+                            <choice name='sportsPack'>1</choice>
+                        </set>
+                    </types>
+                </messageSchema>");
+
+            var results = generator.Generate("TestNamespace", schema, context, default(SourceProductionContext));
+            var setResult = results.First(r => r.name.Contains("TestSet"));
+
+            Assert.Contains("SunRoof", setResult.content);
+            Assert.Contains("SportsPack", setResult.content);
+            Assert.DoesNotContain("sunRoof", setResult.content);
+            Assert.DoesNotContain("sportsPack", setResult.content);
+        }
+
+        [Fact]
+        public void Generate_WithEnum_NormalizesValueNames()
+        {
+            var generator = new TypesCodeGenerator();
+            var context = new SchemaContext("test-schema");
+            var schema = SchemaReader.Parse(@"
+                <messageSchema>
+                    <types>
+                        <enum name='TestEnum' encodingType='uint8'>
+                            <validValue name='fooBar'>0</validValue>
+                            <validValue name='bazQux'>1</validValue>
+                        </enum>
+                    </types>
+                </messageSchema>");
+
+            var results = generator.Generate("TestNamespace", schema, context, default(SourceProductionContext));
+            var enumResult = results.First(r => r.name.Contains("TestEnum"));
+
+            Assert.Contains("FooBar", enumResult.content);
+            Assert.Contains("BazQux", enumResult.content);
+            Assert.DoesNotContain("fooBar", enumResult.content);
+            Assert.DoesNotContain("bazQux", enumResult.content);
+        }
+
+        [Fact]
         public void Generate_WithSet_ProducesSetCode()
         {
             // Arrange

--- a/tests/SbeCodeGenerator.Tests/TypesCodeGeneratorTests.cs
+++ b/tests/SbeCodeGenerator.Tests/TypesCodeGeneratorTests.cs
@@ -966,7 +966,7 @@ namespace SbeCodeGenerator.Tests
             var decimalResult = results.First(r => r.name.Contains("Decimal"));
 
             // Assert
-            Assert.Contains("public override string ToString()", decimalResult.content);
+            Assert.Contains("public readonly override string ToString()", decimalResult.content);
             Assert.Contains("Decimal {{ Mantissa={Mantissa} }}", decimalResult.content);
         }
     }


### PR DESCRIPTION
## Summary

### Bug Fixes
- **Char array in composites**: Fields with `primitiveType="char" length="3"` inside composites now correctly generate InlineArray types instead of single `char` fields. Fixes MESSAGE_SIZE miscalculation.
- **Type generation order**: Standalone types, enums, and sets are now processed before composites, so `<ref>` fields correctly resolve type lengths for MESSAGE_SIZE.
- **Enum/set value naming**: Enum values and set choices are now PascalCased via `NormalizeName()`, consistent with other generated identifiers (`sunRoof` → `SunRoof`, `fooBar` → `FooBar`).
- **Null guard**: `.First()` replaced with `.FirstOrDefault()` + null check in composite field lookup.
- **Schema parsing**: `characterEncoding` attribute now parsed for composite fields (`SchemaFieldDto`).

### New Tests
- **20 edge case integration tests** with new `edge-cases-schema.xml`:
  - Sparse enum values (0, 3, 5, 10, 99)
  - `uint16` sets with 10 choices (>8 bits)
  - Composite with `<ref>` fields (Instrument with IsinCode InlineArray)
  - Multiple `<types>` blocks
  - Constant fields in composites (DecimalEncoding with exponent=-7)
  - Group with data-only fields (no fixed fields) — known issue documented and test skipped
- **Car example** updated to use `MESSAGE_SIZE` (no more `sizeof` workaround)

### Test Results
- 172 unit tests ✅
- 111 integration tests ✅ (1 skipped — known issue with 0-field groups)

### Known Issue
Groups with 0 fixed fields produce a struct where `sizeof(T) = 1` (C# minimum) but `blockLength = 0`. The `ConsumeVariableLengthSegments` reader advances by `sizeof(T)` instead of `blockLength`, causing offset mismatch.