### PR TITLE
feat!: zero-copy MessageDataReader API (v1.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2026-04-10
+
+### Breaking Changes
+- **Zero-copy `MessageDataReader` API**: `TryParse` now returns a `{Message}DataReader` ref struct instead of `(out T message, out ReadOnlySpan<byte> variableData)`. Access fields via `reader.Data` (zero-copy `ref readonly` into the buffer). This is a breaking change for all decode call sites.
+- **`ConsumeVariableLengthSegments` → `ReadGroups`**: Group/varData processing moved from instance method on the data struct to a method on the reader. No separate `variableData` span parameter — the reader manages the buffer internally.
+- **`TryParseWithReader`**: Now returns a `{Message}DataReader` instead of `(out T, out ReadOnlySpan<byte>)`. Caller uses `spanReader.TrySkip(messageReader.BytesConsumed)` to advance past the message.
+
+### Added
+- **`{Message}DataReader` ref struct**: Generated per message. Holds `ReadOnlySpan<byte>` buffer, exposes `ref readonly {Message}Data Data` via `Unsafe.As<byte, T>` for zero-copy field access.
+- **`BytesConsumed` property**: Tracks total bytes consumed by the message (block + groups + varData). Available after `ReadGroups` for messages with variable-length segments.
+- **`ReadGroups` method**: Replaces `ConsumeVariableLengthSegments`. Only generated for messages with groups or varData. Same `in` delegate callback pattern.
+
+### Migration Guide
+
+```csharp
+// Before (v0.9.x):
+if (CarData.TryParse(buffer, out var car, out var variableData))
+{
+    Console.WriteLine(car.SerialNumber);
+    car.ConsumeVariableLengthSegments(variableData,
+        (in FuelFiguresData fuel) => { },
+        (in PerformanceFiguresData perf) => { });
+}
+
+// After (v1.0.0):
+if (CarData.TryParse(buffer, out var car))
+{
+    Console.WriteLine(car.Data.SerialNumber);  // .Data for zero-copy access
+    car.ReadGroups(
+        (in FuelFiguresData fuel) => { },
+        (in PerformanceFiguresData perf) => { });
+}
+
+// Simple messages (no groups):
+// Before: TradeData.TryParse(buffer, out var trade, out _);  trade.Price
+// After:  TradeData.TryParse(buffer, out var trade);         trade.Data.Price
+```
+
 ## [0.9.1] - 2026-04-10
 
 ### Fixed
@@ -155,7 +193,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for primitive types, composites, enums, sets, messages, and groups
 - Comprehensive test suite with snapshot and integration tests
 
-[Unreleased]: https://github.com/pedrosakuma/SbeSourceGenerator/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/pedrosakuma/SbeSourceGenerator/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/pedrosakuma/SbeSourceGenerator/compare/v0.9.1...v1.0.0
+[0.9.1]: https://github.com/pedrosakuma/SbeSourceGenerator/compare/v0.9.0...v0.9.1
+[0.9.0]: https://github.com/pedrosakuma/SbeSourceGenerator/compare/v0.8.0...v0.9.0
+[0.8.0]: https://github.com/pedrosakuma/SbeSourceGenerator/compare/v0.7.0...v0.8.0
+[0.7.0]: https://github.com/pedrosakuma/SbeSourceGenerator/compare/v0.6.0...v0.7.0
+[0.6.0]: https://github.com/pedrosakuma/SbeSourceGenerator/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/pedrosakuma/SbeSourceGenerator/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/pedrosakuma/SbeSourceGenerator/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/pedrosakuma/SbeSourceGenerator/compare/v0.2.0...v0.3.0

--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ if (trade.TryEncode(buffer, out int bytesWritten))
 }
 
 // Decode from binary format
-if (TradeData.TryParse(receivedBuffer, out var decoded, out _))
+if (TradeData.TryParse(receivedBuffer, out var reader))
 {
-    Console.WriteLine($"Trade: {decoded.TradeId}, Price: {decoded.Price}");
+    Console.WriteLine($"Trade: {reader.Data.TradeId}, Price: {reader.Data.Price}");
 }
 ```
 
@@ -118,13 +118,15 @@ bool success = OrderBookData.TryEncode(
     out int bytesWritten
 );
 
-// Decode with groups
-OrderBookData.TryParse(buffer, out var decoded, out var variableData);
-decoded.ConsumeVariableLengthSegments(
-    variableData,
-    (in BidsData bid) => Console.WriteLine($"Bid: {bid.Price}"),
-    (in AsksData ask) => Console.WriteLine($"Ask: {ask.Price}")
-);
+// Decode with groups — zero-copy via MessageDataReader
+if (OrderBookData.TryParse(buffer, out var reader))
+{
+    Console.WriteLine($"Instrument: {reader.Data.InstrumentId}");
+    reader.ReadGroups(
+        (in BidsData bid) => Console.WriteLine($"Bid: {bid.Price}"),
+        (in AsksData ask) => Console.WriteLine($"Ask: {ask.Price}")
+    );
+}
 ```
 
 **Messages with Repeating Groups (Zero-Allocation Callback API):**
@@ -165,15 +167,17 @@ bool success = NewOrderData.TryEncode(
     out int bytesWritten
 );
 
-// Decode varData
-NewOrderData.TryParse(buffer, out var decoded, out var variableData);
-decoded.ConsumeVariableLengthSegments(
-    variableData,
-    symbol => {
-        var text = Encoding.UTF8.GetString(symbol.VarData.Slice(0, symbol.Length));
-        Console.WriteLine($"Symbol: {text}");
-    }
-);
+// Decode varData — zero-copy via MessageDataReader
+if (NewOrderData.TryParse(buffer, out var reader))
+{
+    Console.WriteLine($"Order: {reader.Data.OrderId}");
+    reader.ReadGroups(
+        symbol => {
+            var text = Encoding.UTF8.GetString(symbol.VarData.Slice(0, symbol.Length));
+            Console.WriteLine($"Symbol: {text}");
+        }
+    );
+}
 ```
 
 ## Example Schema

--- a/README.md
+++ b/README.md
@@ -27,6 +27,23 @@ A Roslyn-based source generator that converts FIX Simple Binary Encoding (SBE) X
 - Validation constraints (min/max ranges)
 - Comprehensive build-time diagnostics (SBE001–SBE014)
 
+## What's New in v1.0.0
+
+**Zero-copy `MessageDataReader`** — `TryParse` now returns a lightweight ref struct that holds a reference directly into the buffer. Access fields via `reader.Data` (zero-copy `ref readonly`) and process groups via `reader.ReadGroups(...)`.
+
+```csharp
+if (CarData.TryParse(buffer, out var car))
+{
+    Console.WriteLine(car.Data.SerialNumber);  // zero-copy field access
+    car.ReadGroups(
+        (in FuelFiguresData fuel) => { /* ... */ },
+        (in PerformanceFiguresData perf, AccelerationData.AccelerationHandler onAccel) => { /* ... */ });
+    Console.WriteLine($"Total bytes: {car.BytesConsumed}");
+}
+```
+
+> **Migrating from v0.9.x?** See the [migration guide in CHANGELOG.md](./CHANGELOG.md#100---2026-04-10).
+
 ## Quick Start
 
 ### 1. Install
@@ -41,7 +58,7 @@ Or add it directly to your `.csproj`:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="SbeSourceGenerator" Version="0.9.1" />
+  <PackageReference Include="SbeSourceGenerator" Version="1.0.0" />
 </ItemGroup>
 ```
 
@@ -336,8 +353,9 @@ The repository includes several example projects in the `examples/` folder:
 
 The generated code is designed for high performance:
 
-- Zero-copy deserialization with `ReadBlockRef<T>` (ref readonly into buffer)
-- `in` delegate callbacks for group consume (no struct copies)
+- Zero-copy deserialization via `MessageDataReader` ref struct (`reader.Data` is `ref readonly` into buffer)
+- Zero-copy `ReadBlockRef<T>` for advanced SpanReader usage
+- `ReadGroups` with `in` delegate callbacks (no struct copies)
 - `readonly` property getters to prevent defensive copies
 - Struct-based value types (no heap allocations)
 - Explicit memory layout for cache efficiency
@@ -385,4 +403,4 @@ For questions, issues, or feature requests:
 
 ---
 
-**Version**: 0.9.1 (see [Changelog](./CHANGELOG.md))
+**Version**: 1.0.0 (see [Changelog](./CHANGELOG.md))

--- a/docs/PERFORMANCE_TUNING_GUIDE.md
+++ b/docs/PERFORMANCE_TUNING_GUIDE.md
@@ -19,11 +19,11 @@ This guide provides best practices and techniques for optimizing the performance
 The generated SBE code is designed for zero-copy operations:
 
 ```csharp
-// ✅ Good: Zero-copy parsing
+// ✅ Good: Zero-copy parsing via MessageDataReader
 ReadOnlySpan<byte> buffer = GetNetworkData();
-if (TradeData.TryParse(buffer, out var trade, out _))
+if (TradeData.TryParse(buffer, out var trade))
 {
-    ProcessTrade(trade); // No copying
+    ProcessTrade(in trade.Data); // Zero-copy ref readonly access
 }
 
 // ❌ Bad: Unnecessary copying
@@ -179,36 +179,37 @@ if (trade.Price > minPrice && trade.Price < maxPrice)
 
 ### Use TryParse for Validation
 
-The `TryParse` pattern is optimized for performance:
+The `TryParse` pattern returns a zero-copy `MessageDataReader`:
 
 ```csharp
 // ✅ Good: TryParse with minimal validation
-if (TradeData.TryParse(buffer, out var trade, out var variableData))
+if (TradeData.TryParse(buffer, out var trade))
 {
-    ProcessTrade(trade);
+    ProcessTrade(in trade.Data);
 }
 
 // ⚠️ Slower: Additional validation
-if (TradeData.TryParse(buffer, out var trade, out _))
+if (TradeData.TryParse(buffer, out var trade))
 {
-    trade.Validate(); // Extra overhead
-    ProcessTrade(trade);
+    trade.Data.Validate(); // Extra overhead
+    ProcessTrade(in trade.Data);
 }
 ```
 
 ### Minimize Copies
 
 ```csharp
-// ✅ Good: Work directly with parsed data
-if (TradeData.TryParse(buffer, out var trade, out _))
+// ✅ Good: Work directly with zero-copy reader
+if (TradeData.TryParse(buffer, out var trade))
 {
-    ProcessTradeInPlace(ref trade); // Pass by reference
+    // trade.Data is ref readonly — zero copy
+    ProcessPrice(trade.Data.Price);
 }
 
-// ❌ Bad: Create copy
-if (TradeData.TryParse(buffer, out var trade, out _))
+// ❌ Bad: Create unnecessary copy
+if (TradeData.TryParse(buffer, out var trade))
 {
-    var tradeCopy = trade; // Unnecessary copy
+    TradeData tradeCopy = trade.Data; // Explicit copy
     ProcessTrade(tradeCopy);
 }
 ```
@@ -218,22 +219,25 @@ if (TradeData.TryParse(buffer, out var trade, out _))
 For large messages, process groups incrementally:
 
 ```csharp
-// ✅ Good: Process groups as they're consumed (v0.9.0 uses in delegates)
-MarketDataData.TryParse(buffer, out var data, out var variableData);
-data.ConsumeVariableLengthSegments(
-    variableData,
-    (in BidData bid) => ProcessBid(in bid),    // Zero-copy via in
-    (in AskData ask) => ProcessAsk(in ask)     // Zero-copy via in
-);
+// ✅ Good: Process groups as they're consumed via ReadGroups (v1.0.0)
+if (MarketDataData.TryParse(buffer, out var reader))
+{
+    reader.ReadGroups(
+        (in BidData bid) => ProcessBid(in bid),    // Zero-copy via in
+        (in AskData ask) => ProcessAsk(in ask)     // Zero-copy via in
+    );
+}
 
 // ❌ Bad: Collect all groups first
 var bids = new List<BidData>(); // Heap allocations
 var asks = new List<AskData>();
-data.ConsumeVariableLengthSegments(
-    variableData,
-    (in BidData bid) => bids.Add(bid),
-    (in AskData ask) => asks.Add(ask)
-);
+if (MarketDataData.TryParse(buffer, out var reader))
+{
+    reader.ReadGroups(
+        (in BidData bid) => bids.Add(bid),
+        (in AskData ask) => asks.Add(ask)
+    );
+}
 ProcessBids(bids);
 ProcessAsks(asks);
 ```
@@ -247,41 +251,47 @@ Process repeating groups without materializing collections:
 ```csharp
 // ✅ Good: Streaming processing
 long totalVolume = 0;
-data.ConsumeVariableLengthSegments(
-    variableData,
-    (in BidData bid) => totalVolume += bid.Quantity,
-    (in AskData ask) => totalVolume += ask.Quantity
-);
+if (MarketDataData.TryParse(buffer, out var reader))
+{
+    reader.ReadGroups(
+        (in BidData bid) => totalVolume += bid.Quantity,
+        (in AskData ask) => totalVolume += ask.Quantity
+    );
+}
 
 // ❌ Bad: Materialize groups
 var allBids = new List<BidData>();
 var allAsks = new List<AskData>();
-data.ConsumeVariableLengthSegments(
-    variableData,
-    (in BidData bid) => allBids.Add(bid),
-    (in AskData ask) => allAsks.Add(ask)
-);
+if (MarketDataData.TryParse(buffer, out var reader))
+{
+    reader.ReadGroups(
+        (in BidData bid) => allBids.Add(bid),
+        (in AskData ask) => allAsks.Add(ask)
+    );
+}
 long totalVolume = allBids.Sum(b => b.Quantity) + allAsks.Sum(a => a.Quantity);
 ```
 
 ### Early Exit
 
-Note: The current `ConsumeVariableLengthSegments` callbacks use `void`-returning `in` delegates, so early exit must use external state:
+Note: The `ReadGroups` callbacks use `void`-returning `in` delegates, so early exit must use external state:
 
 ```csharp
 // ✅ Good: Early exit via external flag
 bool found = false;
-data.ConsumeVariableLengthSegments(
-    variableData,
-    (in BidData bid) =>
-    {
-        if (!found && bid.Price == targetPrice)
+if (MarketDataData.TryParse(buffer, out var reader))
+{
+    reader.ReadGroups(
+        (in BidData bid) =>
         {
-            found = true;
-        }
-    },
-    (in AskData ask) => { }
-);
+            if (!found && bid.Price == targetPrice)
+            {
+                found = true;
+            }
+        },
+        (in AskData ask) => { }
+    );
+}
 
 // ❌ Bad: Process all groups
 var match = allBids.FirstOrDefault(b => b.Price == targetPrice);
@@ -296,11 +306,13 @@ When group sizes are known, pre-allocate:
 Span<BidData> bids = stackalloc BidData[expectedBidCount];
 int bidIndex = 0;
 
-data.ConsumeVariableLengthSegments(
-    variableData,
-    bid => bids[bidIndex++] = bid,
-    ask => { }
-);
+if (MarketDataData.TryParse(buffer, out var reader))
+{
+    reader.ReadGroups(
+        (in BidData bid) => bids[bidIndex++] = bid,
+        (in AskData ask) => { }
+    );
+}
 
 // Process bids array directly
 ProcessBids(bids.Slice(0, bidIndex));
@@ -425,20 +437,18 @@ void ProcessTrade(in Trade trade)
 ```csharp
 // ❌ Bad: Closure allocation
 int threshold = 100;
-data.ConsumeVariableLengthSegments(
-    variableData,
-    bid => bid.Quantity > threshold, // Closure - allocation
-    ask => true
+reader.ReadGroups(
+    (in BidData bid) => { _ = bid.Quantity > threshold; }, // Closure - allocation
+    (in AskData ask) => { }
 );
 
 // ✅ Good: Use local function or avoid capture
 bool ProcessBid(BidData bid, int threshold) 
     => bid.Quantity > threshold;
 
-data.ConsumeVariableLengthSegments(
-    variableData,
-    bid => ProcessBid(bid, 100),
-    ask => true
+reader.ReadGroups(
+    (in BidData bid) => ProcessBid(bid, 100),
+    (in AskData ask) => { }
 );
 ```
 

--- a/docs/SCHEMA_VERSIONING.md
+++ b/docs/SCHEMA_VERSIONING.md
@@ -61,24 +61,24 @@ public long Quantity;
 
 ### TryParse Methods
 
-The generated `TryParse` method uses `TryReadBlock<T>` for version-aware parsing:
+The generated `TryParse` method returns a zero-copy `MessageDataReader` ref struct:
 
 ```csharp
 public static bool TryParse(ReadOnlySpan<byte> buffer, int blockLength, 
-                           out OrderData message, out ReadOnlySpan<byte> variableData)
+                           out OrderDataReader reader)
 {
-    var reader = new SpanReader(buffer);
+    var spanReader = new SpanReader(buffer);
     
     // TryReadBlock advances by blockLength, not sizeof(T)
     // - blockLength < sizeof: partial read, trailing fields zeroed (backward compat)
     // - blockLength > sizeof: full read, skips extra bytes (forward compat)
-    if (!reader.TryReadBlock<OrderData>(blockLength, out message))
+    if (!spanReader.TryReadBlock<OrderData>(blockLength, out _))
     {
-        variableData = default;
+        reader = default;
         return false;
     }
     
-    variableData = reader.Remaining;
+    reader = new OrderDataReader(buffer, blockLength);
     return true;
 }
 ```
@@ -95,15 +95,15 @@ Span<byte> v1Message = /* ... from wire or storage ... */;
 int v1BlockLength = 16;
 
 // V3 decoder can read V1 messages
-var success = OrderData.TryParse(v1Message, v1BlockLength, out var order, out var varData);
+var success = OrderData.TryParse(v1Message, v1BlockLength, out var order);
 
 // Fields present in V1
-Console.WriteLine($"OrderId: {order.OrderId}");  // ✓ Present
-Console.WriteLine($"Price: {order.Price}");      // ✓ Present
+Console.WriteLine($"OrderId: {order.Data.OrderId}");  // ✓ Present
+Console.WriteLine($"Price: {order.Data.Price}");      // ✓ Present
 
 // Fields added in later versions have default values
-Console.WriteLine($"Quantity: {order.Quantity}"); // 0 (not in V1)
-Console.WriteLine($"Side: {order.Side}");         // 0 (not in V2)
+Console.WriteLine($"Quantity: {order.Data.Quantity}"); // 0 (not in V1)
+Console.WriteLine($"Side: {order.Data.Side}");         // 0 (not in V2)
 ```
 
 ### Example 2: Writing Messages with the Latest Schema
@@ -132,15 +132,15 @@ Span<byte> v3Message = /* ... 25 bytes ... */;
 
 // V1 decoder only knows about blockLength=16
 int v1BlockLength = 16;
-var success = OrderData.TryParse(v3Message, v1BlockLength, out var order, out var remaining);
+var success = OrderData.TryParse(v3Message, v1BlockLength, out var order);
 
 // V1 decoder reads its known fields
-Console.WriteLine($"OrderId: {order.OrderId}");  // ✓ Read correctly
-Console.WriteLine($"Price: {order.Price}");      // ✓ Read correctly
+Console.WriteLine($"OrderId: {order.Data.OrderId}");  // ✓ Read correctly
+Console.WriteLine($"Price: {order.Data.Price}");      // ✓ Read correctly
 
 // Unknown fields (quantity, side) are skipped
 // They're still in the struct but V1 code shouldn't access them
-// remaining.Length will be 9 bytes (the unread portion)
+// reader.BytesConsumed will be 25 bytes (the blockLength)
 ```
 
 ## Schema Evolution Best Practices

--- a/docs/SPAN_READER_INTEGRATION.md
+++ b/docs/SPAN_READER_INTEGRATION.md
@@ -8,10 +8,10 @@ This document describes the integration of the `SpanReader` abstraction into the
 
 ## Background
 
-Prior to this integration, the generated `ConsumeVariableLengthSegments` method used manual offset tracking:
+Prior to this integration, the generated `ReadGroups` method (formerly `ConsumeVariableLengthSegments`) used manual offset tracking:
 
 ```csharp
-public void ConsumeVariableLengthSegments(ReadOnlySpan<byte> buffer, ...)
+public void ReadGroups(...)
 {
     int offset = 0;  // Manual offset management
     
@@ -41,7 +41,7 @@ This approach was error-prone due to:
 The integration involved updating the `MessageDefinition` class in the source generator to emit `SpanReader`-based parsing code:
 
 ```csharp
-public void ConsumeVariableLengthSegments(ReadOnlySpan<byte> buffer, ...)
+public void ReadGroups(...)
 {
     var reader = new SpanReader(buffer);
     
@@ -118,7 +118,7 @@ Variable-length data fields work correctly:
 
 ### Integration Tests
 Added comprehensive integration tests:
-1. **Group Parsing Test**: Verifies `ConsumeVariableLengthSegments` correctly parses bids and asks groups using SpanReader
+1. **Group Parsing Test**: Verifies `ReadGroups` correctly parses bids and asks groups using SpanReader
 2. **Data Fields Test**: Validates VarString8 data field parsing with SpanReader
 3. All 119 integration tests passing ✅
 
@@ -148,12 +148,16 @@ Added comprehensive integration tests:
 - Nested groups use depth-indexed variable names (`nestedData1`, `nestedData2`)
 
 ### For Library Users
-- **Breaking Change (v0.9.0)**: Group callbacks changed from `Action<GroupData>` to `{GroupName}Handler(in GroupData data)`. Add `in` keyword to lambda parameters:
+- **Breaking Change (v1.0.0)**: `TryParse` now returns a zero-copy `MessageDataReader` ref struct. Access fields via `reader.Data.Field`. Group processing moved to `reader.ReadGroups(...)`:
   ```csharp
-  // Before:
-  decoded.ConsumeVariableLengthSegments(buffer, bid => ProcessBid(bid));
-  // After:
-  decoded.ConsumeVariableLengthSegments(buffer, (in BidsData bid) => ProcessBid(bid));
+  // Before (v0.9.x):
+  OrderBookData.TryParse(buffer, out var decoded, out var variableData);
+  decoded.ConsumeVariableLengthSegments(variableData, (in BidsData bid) => ProcessBid(bid));
+  // After (v1.0.0):
+  if (OrderBookData.TryParse(buffer, out var reader))
+  {
+      reader.ReadGroups((in BidsData bid) => ProcessBid(in bid));
+  }
   ```
 - `TryParse` now uses `TryReadBlock<T>` internally for correct schema evolution handling
 - Generated `readonly` property getters prevent defensive copies when accessed through `in` refs

--- a/docs/SPAN_READER_README.md
+++ b/docs/SPAN_READER_README.md
@@ -348,7 +348,37 @@ if (reader.TryPeek<MessageHeader>(out var header))
 }
 ```
 
-### Callback Pattern (v0.9.0+)
+### TryParseWithReader (v1.0.0+)
+
+For sequential message reading with `SpanReader`, use `TryParseWithReader` to get a `MessageDataReader` without advancing the reader:
+
+```csharp
+var reader = new SpanReader(buffer);
+
+// Read message header
+if (reader.TryRead<MessageHeader>(out var header))
+{
+    // Parse message body — reader is NOT advanced
+    if (OrderBookData.TryParseWithReader(ref reader, header.BlockLength, out var orderBook))
+    {
+        // Access fields zero-copy
+        Console.WriteLine($"Instrument: {orderBook.Data.InstrumentId}");
+        
+        // Process groups
+        orderBook.ReadGroups(
+            (in BidsData bid) => ProcessBid(in bid),
+            (in AsksData ask) => ProcessAsk(in ask)
+        );
+        
+        // Advance reader past the entire message
+        reader.TrySkip(orderBook.BytesConsumed);
+    }
+}
+```
+
+This pattern is ideal for reading multiple messages from a single buffer, where each message's total size (block + groups + varData) is tracked by `BytesConsumed`.
+
+### Callback Pattern (v1.0.0+)
 
 Generated code uses custom delegates with `in` parameters to avoid struct copies:
 

--- a/docs/SPAN_READER_README.md
+++ b/docs/SPAN_READER_README.md
@@ -357,11 +357,14 @@ Generated code uses custom delegates with `in` parameters to avoid struct copies
 // public delegate void BidsHandler(in BidsData data);
 // public delegate void AsksHandler(in AsksData data);
 
-decoded.ConsumeVariableLengthSegments(
-    variableData,
-    (in BidsData bid) => Console.WriteLine($"Bid: {bid.Price}"),
-    (in AsksData ask) => Console.WriteLine($"Ask: {ask.Price}")
-);
+// Via MessageDataReader (v1.0.0):
+if (OrderBookData.TryParse(buffer, out var reader))
+{
+    reader.ReadGroups(
+        (in BidsData bid) => Console.WriteLine($"Bid: {bid.Price}"),
+        (in AsksData ask) => Console.WriteLine($"Ask: {ask.Price}")
+    );
+}
 ```
 
 For manual parsing with TryReadBlock:

--- a/examples/HighPerformanceMarketData/Program.cs
+++ b/examples/HighPerformanceMarketData/Program.cs
@@ -58,12 +58,12 @@ class Program
             Console.WriteLine($"✓ Encoded quote: {written} bytes");
             
             // Decode
-            if (QuoteData.TryParse(buffer, out var decoded, out _))
+            if (QuoteData.TryParse(buffer, out var decoded))
             {
-                Console.WriteLine($"  Instrument: {decoded.InstrumentId}");
-                Console.WriteLine($"  Bid: {(long)decoded.BidPrice / 10000.0:F4} x {decoded.BidQuantity}");
-                Console.WriteLine($"  Ask: {(long)decoded.AskPrice / 10000.0:F4} x {decoded.AskQuantity}");
-                Console.WriteLine($"  Spread: {((long)decoded.AskPrice - (long)decoded.BidPrice) / 10000.0:F4}");
+                Console.WriteLine($"  Instrument: {decoded.Data.InstrumentId}");
+                Console.WriteLine($"  Bid: {(long)decoded.Data.BidPrice / 10000.0:F4} x {decoded.Data.BidQuantity}");
+                Console.WriteLine($"  Ask: {(long)decoded.Data.AskPrice / 10000.0:F4} x {decoded.Data.AskQuantity}");
+                Console.WriteLine($"  Spread: {((long)decoded.Data.AskPrice - (long)decoded.Data.BidPrice) / 10000.0:F4}");
             }
         }
         
@@ -94,12 +94,12 @@ class Program
         {
             Console.WriteLine($"✓ Encoded trade: {written} bytes");
             
-            if (TradeData.TryParse(buffer, out var decoded, out _))
+            if (TradeData.TryParse(buffer, out var decoded))
             {
-                Console.WriteLine($"  Trade ID: {decoded.TradeId}");
-                Console.WriteLine($"  Price: {(long)decoded.Price / 10000.0:F4}");
-                Console.WriteLine($"  Quantity: {decoded.Quantity}");
-                Console.WriteLine($"  Side: {decoded.Side}");
+                Console.WriteLine($"  Trade ID: {decoded.Data.TradeId}");
+                Console.WriteLine($"  Price: {(long)decoded.Data.Price / 10000.0:F4}");
+                Console.WriteLine($"  Quantity: {decoded.Data.Quantity}");
+                Console.WriteLine($"  Side: {decoded.Data.Side}");
             }
         }
         
@@ -149,11 +149,11 @@ class Program
             
             for (int i = 0; i < batchSize; i++)
             {
-                if (QuoteData.TryParse(buffer.AsSpan(offset), out var quote, out _))
+                if (QuoteData.TryParse(buffer.AsSpan(offset), out var quote))
                 {
                     offset += QuoteData.MESSAGE_SIZE;
                     decodedCount++;
-                    totalSpread += ((long)quote.AskPrice - (long)quote.BidPrice);
+                    totalSpread += ((long)quote.Data.AskPrice - (long)quote.Data.BidPrice);
                 }
             }
             
@@ -195,7 +195,7 @@ class Program
             for (int i = 0; i < 1000; i++)
             {
                 quote.TryEncode(buffer, out _);
-                QuoteData.TryParse(buffer, out _, out _);
+                QuoteData.TryParse(buffer, out _);
             }
             
             // Measure encoding
@@ -216,7 +216,7 @@ class Program
             sw.Restart();
             for (int i = 0; i < iterations; i++)
             {
-                QuoteData.TryParse(buffer, out _, out _);
+                QuoteData.TryParse(buffer, out _);
             }
             sw.Stop();
             
@@ -230,7 +230,7 @@ class Program
             for (int i = 0; i < iterations; i++)
             {
                 quote.TryEncode(buffer, out _);
-                QuoteData.TryParse(buffer, out _, out _);
+                QuoteData.TryParse(buffer, out _);
             }
             sw.Stop();
             

--- a/examples/HighPerformanceMarketData/README.md
+++ b/examples/HighPerformanceMarketData/README.md
@@ -87,11 +87,13 @@ finally
 
 ```csharp
 // Process groups without materializing collections
-snapshot.ConsumeVariableLengthSegments(
-    variableData,
-    bid => ProcessBid(bid),  // Process each bid immediately
-    ask => ProcessAsk(ask)   // Process each ask immediately
-);
+if (DepthSnapshotData.TryParse(buffer, out var reader))
+{
+    reader.ReadGroups(
+        (in BidsData bid) => ProcessBid(in bid),  // Process each bid immediately
+        (in AsksData ask) => ProcessAsk(in ask)   // Process each ask immediately
+    );
+}
 ```
 
 ### Batch Processing

--- a/src/SbeCodeGenerator/Generators/Types/MessageDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Types/MessageDefinition.cs
@@ -59,7 +59,7 @@ namespace SbeSourceGenerator
             AppendParseHelpers(sb, tabs);
             AppendEncodeHelpers(sb, tabs);
             AppendGroupsFileContent(sb, tabs);
-            AppendConsumeVariable(sb, tabs);
+            AppendDelegateTypes(sb, tabs);
             
             // Generate comprehensive TryEncode method if message has groups or varData
             if (HasVariableData)
@@ -71,36 +71,44 @@ namespace SbeSourceGenerator
             AppendWriteHeader(sb, tabs);
             
             sb.AppendLine("}", --tabs);
+
+            AppendReaderStruct(sb, tabs);
         }
 
         private void AppendParseHelpers(StringBuilder sb, int tabs)
         {
-            // Original TryParse without blockLength parameter for backward compatibility
+            // TryParse without blockLength parameter
             sb.AppendLine("[MethodImpl(MethodImplOptions.AggressiveInlining)]", tabs);
-            sb.AppendTabs(tabs).Append("public static bool TryParse(ReadOnlySpan<byte> buffer, out ").Append(Name).AppendLine("Data message, out ReadOnlySpan<byte> variableData)");
+            sb.AppendTabs(tabs).Append("public static bool TryParse(ReadOnlySpan<byte> buffer, out ").Append(Name).AppendLine("DataReader reader)");
             sb.AppendLine("{", tabs++);
-            sb.AppendTabs(tabs).AppendLine("return TryParse(buffer, BLOCK_LENGTH, out message, out variableData);");
+            sb.AppendTabs(tabs).AppendLine("return TryParse(buffer, BLOCK_LENGTH, out reader);");
             sb.AppendLine("}", --tabs);
 
             // TryParse with blockLength parameter for schema evolution support
             sb.AppendLine("[MethodImpl(MethodImplOptions.AggressiveInlining)]", tabs);
-            sb.AppendTabs(tabs).Append("public static bool TryParse(ReadOnlySpan<byte> buffer, int blockLength, out ").Append(Name).AppendLine("Data message, out ReadOnlySpan<byte> variableData)");
+            sb.AppendTabs(tabs).Append("public static bool TryParse(ReadOnlySpan<byte> buffer, int blockLength, out ").Append(Name).AppendLine("DataReader reader)");
             sb.AppendLine("{", tabs++);
-            sb.AppendLine("var reader = new SpanReader(buffer);", tabs);
-            sb.AppendTabs(tabs).Append("if (!reader.TryReadBlock<").Append(Name).AppendLine("Data>(blockLength, out message))");
+            sb.AppendTabs(tabs).AppendLine("if (buffer.Length < blockLength)");
             sb.AppendLine("{", tabs++);
-            sb.AppendLine("variableData = default;", tabs);
+            sb.AppendLine("reader = default;", tabs);
             sb.AppendLine("return false;", tabs);
             sb.AppendLine("}", --tabs);
-            sb.AppendLine("variableData = reader.Remaining;", tabs);
+            sb.AppendTabs(tabs).Append("reader = new ").Append(Name).AppendLine("DataReader(buffer, blockLength);");
             sb.AppendLine("return true;", tabs);
             sb.AppendLine("}", --tabs);
 
-            // Public method that uses SpanReader for parsing - reader is passed by ref to update offset in caller
+            // TryParseWithReader for sequential reading from a SpanReader
             sb.AppendLine("[MethodImpl(MethodImplOptions.AggressiveInlining)]", tabs);
-            sb.AppendTabs(tabs).Append("public static bool TryParseWithReader(ref SpanReader reader, int blockLength, out ").Append(Name).AppendLine("Data message)");
+            sb.AppendTabs(tabs).Append("public static bool TryParseWithReader(ref SpanReader reader, int blockLength, out ").Append(Name).AppendLine("DataReader messageReader)");
             sb.AppendLine("{", tabs++);
-            sb.AppendTabs(tabs).Append("return reader.TryReadBlock<").Append(Name).AppendLine("Data>(blockLength, out message);");
+            sb.AppendTabs(tabs).AppendLine("var remaining = reader.Remaining;");
+            sb.AppendTabs(tabs).AppendLine("if (remaining.Length < blockLength)");
+            sb.AppendLine("{", tabs++);
+            sb.AppendLine("messageReader = default;", tabs);
+            sb.AppendLine("return false;", tabs);
+            sb.AppendLine("}", --tabs);
+            sb.AppendTabs(tabs).Append("messageReader = new ").Append(Name).AppendLine("DataReader(remaining, blockLength);");
+            sb.AppendLine("return true;", tabs);
             sb.AppendLine("}", --tabs);
         }
 
@@ -221,43 +229,16 @@ namespace SbeSourceGenerator
             }
         }
 
-        private void AppendConsumeVariable(StringBuilder sb, int tabs)
+        private void AppendDelegateTypes(StringBuilder sb, int tabs)
         {
             if (HasVariableData)
             {
-                // Generate delegate types for zero-copy group callbacks
                 foreach (var group in TypedGroups)
                     AppendGroupDelegateTypes(sb, tabs, group);
-
-                // Build callback parameter lists once
-                var callbackParams = BuildCallbackParams();
-                var callbackArgs = BuildCallbackArgs();
-
-                // Original overload that creates its own SpanReader
-                sb.AppendTabs(tabs).Append("public void ConsumeVariableLengthSegments(ReadOnlySpan<byte> buffer, ").Append(callbackParams).AppendLine(")");
-                sb.AppendLine("{", tabs++);
-                sb.AppendLine("var reader = new SpanReader(buffer);", tabs);
-                sb.AppendTabs(tabs).Append("ConsumeVariableLengthSegments(ref reader, ").Append(callbackArgs).AppendLine(");");
-                sb.AppendLine("}", --tabs);
-
-                // New overload that accepts SpanReader by reference
-                sb.AppendTabs(tabs).Append("public void ConsumeVariableLengthSegments(ref SpanReader reader, ").Append(callbackParams).AppendLine(")");
-                sb.AppendLine("{", tabs++);
-                foreach (var group in TypedGroups)
-                {
-                    AppendGroupConsume(sb, tabs, group);
-                }
-                foreach (var data in TypedDatas)
-                {
-                    sb.AppendTabs(tabs).Append("var datas").Append(data.Name).Append(" = ").Append(data.Type).AppendLine(".Create(reader.Remaining);");
-                    sb.AppendTabs(tabs).Append("callback").Append(data.Name).Append("(datas").Append(data.Name).AppendLine(");");
-                    sb.AppendTabs(tabs).Append("reader.TrySkip(datas").Append(data.Name).AppendLine(".TotalLength);");
-                }
-                sb.AppendLine("}", --tabs);
             }
         }
 
-        private static void AppendGroupConsume(StringBuilder sb, int tabs, GroupDefinition group, List<string>? ancestorVarNames = null)
+        private static void AppendGroupConsume(StringBuilder sb, int tabs, GroupDefinition group, List<string>? ancestorVarNames = null, string dataTypePrefix = "")
         {
             var ancestors = ancestorVarNames ?? new List<string>();
             var depth = ancestors.Count;
@@ -268,7 +249,7 @@ namespace SbeSourceGenerator
             sb.AppendLine("{", tabs++);
             sb.AppendTabs(tabs).Append("for (int ").Append(loopVar).Append(" = 0; ").Append(loopVar).Append(" < group").Append(group.Name).Append(".NumInGroup; ").Append(loopVar).AppendLine("++)");
             sb.AppendLine("{", tabs++);
-            sb.AppendTabs(tabs).Append("if (!reader.TryReadBlock<").Append(group.Name).Append("Data>(group").Append(group.Name).Append(".BlockLength, out var ").Append(dataVarName).AppendLine("))");
+            sb.AppendTabs(tabs).Append("if (!reader.TryReadBlock<").Append(dataTypePrefix).Append(group.Name).Append("Data>(group").Append(group.Name).Append(".BlockLength, out var ").Append(dataVarName).AppendLine("))");
             sb.AppendLine("{", tabs++);
             sb.AppendLine("break;", tabs);
             sb.AppendLine("}", --tabs);
@@ -293,7 +274,7 @@ namespace SbeSourceGenerator
             ancestorsForChildren.Add(dataVarName);
             foreach (var nestedGroup in group.TypedNestedGroups)
             {
-                AppendGroupConsume(sb, tabs, nestedGroup, ancestorsForChildren);
+                AppendGroupConsume(sb, tabs, nestedGroup, ancestorsForChildren, dataTypePrefix);
             }
             sb.AppendLine("}", --tabs);
             sb.AppendLine("}", --tabs);
@@ -574,20 +555,20 @@ namespace SbeSourceGenerator
             }
         }
 
-        private string BuildCallbackParams()
+        private string BuildCallbackParams(string delegateTypePrefix = "")
         {
             var parts = new List<string>(TypedGroups.Count + TypedDatas.Count);
             foreach (var group in TypedGroups)
-                AppendGroupCallbackParams(parts, group);
+                AppendGroupCallbackParams(parts, group, delegateTypePrefix: delegateTypePrefix);
             foreach (var data in TypedDatas)
                 parts.Add($"{data.Type}.Callback callback{data.Name}");
             return string.Join(", ", parts);
         }
 
-        private static void AppendGroupCallbackParams(List<string> parts, GroupDefinition group, List<string>? ancestorTypes = null)
+        private static void AppendGroupCallbackParams(List<string> parts, GroupDefinition group, List<string>? ancestorTypes = null, string delegateTypePrefix = "")
         {
             var ancestors = ancestorTypes ?? new List<string>();
-            parts.Add($"{group.Name}Handler callback{group.Name}");
+            parts.Add($"{delegateTypePrefix}{group.Name}Handler callback{group.Name}");
 
             foreach (var groupData in group.TypedDatas)
                 parts.Add($"{groupData.Type}.Callback callback{group.Name}{groupData.Name}");
@@ -595,7 +576,7 @@ namespace SbeSourceGenerator
             var ancestorsForChildren = new List<string>(ancestors);
             ancestorsForChildren.Add($"{group.Name}Data");
             foreach (var nestedGroup in group.TypedNestedGroups)
-                AppendGroupCallbackParams(parts, nestedGroup, ancestorsForChildren);
+                AppendGroupCallbackParams(parts, nestedGroup, ancestorsForChildren, delegateTypePrefix);
         }
 
         private string BuildCallbackArgs()
@@ -615,6 +596,79 @@ namespace SbeSourceGenerator
                 parts.Add($"callback{group.Name}{groupData.Name}");
             foreach (var nestedGroup in group.TypedNestedGroups)
                 AppendGroupCallbackArgs(parts, nestedGroup);
+        }
+
+        private void AppendReaderStruct(StringBuilder sb, int tabs)
+        {
+            sb.AppendLine("", tabs);
+            sb.AppendLine("/// <summary>", tabs);
+            sb.AppendTabs(tabs).Append("/// Zero-copy reader for ").Append(Name).AppendLine("Data messages.");
+            sb.AppendLine("/// Provides direct access to the message data in the underlying buffer without copying.", tabs);
+            sb.AppendLine("/// </summary>", tabs);
+            sb.AppendTabs(tabs).Append("public ref struct ").Append(Name).AppendLine("DataReader");
+            sb.AppendLine("{", tabs++);
+
+            sb.AppendLine("private readonly ReadOnlySpan<byte> _buffer;", tabs);
+            sb.AppendLine("private readonly int _blockLength;", tabs);
+            sb.AppendLine("", tabs);
+
+            // BytesConsumed property
+            sb.AppendLine("/// <summary>", tabs);
+            sb.AppendLine("/// Total bytes consumed from the buffer (block + variable-length data).", tabs);
+            sb.AppendLine("/// Updated after ReadGroups is called for messages with groups or varData.", tabs);
+            sb.AppendLine("/// </summary>", tabs);
+            sb.AppendLine("public int BytesConsumed { get; private set; }", tabs);
+            sb.AppendLine("", tabs);
+
+            // Constructor
+            sb.AppendLine("[MethodImpl(MethodImplOptions.AggressiveInlining)]", tabs);
+            sb.AppendTabs(tabs).Append("internal ").Append(Name).AppendLine("DataReader(ReadOnlySpan<byte> buffer, int blockLength)");
+            sb.AppendLine("{", tabs++);
+            sb.AppendLine("_buffer = buffer;", tabs);
+            sb.AppendLine("_blockLength = blockLength;", tabs);
+            sb.AppendLine("BytesConsumed = blockLength;", tabs);
+            sb.AppendLine("}", --tabs);
+            sb.AppendLine("", tabs);
+
+            // Data property — zero-copy ref into buffer
+            sb.AppendLine("/// <summary>", tabs);
+            sb.AppendTabs(tabs).Append("/// Gets a readonly reference to the ").Append(Name).AppendLine("Data directly in the buffer (zero-copy).");
+            sb.AppendLine("/// </summary>", tabs);
+            sb.AppendTabs(tabs).Append("public ref readonly ").Append(Name).Append("Data Data => ref Unsafe.As<byte, ").Append(Name).AppendLine("Data>(ref MemoryMarshal.GetReference(_buffer));");
+
+            // ReadGroups — only for messages with variable data
+            if (HasVariableData)
+            {
+                AppendReadGroups(sb, tabs);
+            }
+
+            sb.AppendLine("}", --tabs);
+        }
+
+        private void AppendReadGroups(StringBuilder sb, int tabs)
+        {
+            var callbackParams = BuildCallbackParams($"{Name}Data.");
+            sb.AppendLine("", tabs);
+            sb.AppendLine("/// <summary>", tabs);
+            sb.AppendLine("/// Reads groups and variable-length data from the message buffer using callbacks.", tabs);
+            sb.AppendLine("/// </summary>", tabs);
+            sb.AppendTabs(tabs).Append("public void ReadGroups(").Append(callbackParams).AppendLine(")");
+            sb.AppendLine("{", tabs++);
+            sb.AppendLine("var reader = new SpanReader(_buffer.Slice(_blockLength));", tabs);
+
+            foreach (var group in TypedGroups)
+            {
+                AppendGroupConsume(sb, tabs, group, dataTypePrefix: $"{Name}Data.");
+            }
+            foreach (var data in TypedDatas)
+            {
+                sb.AppendTabs(tabs).Append("var datas").Append(data.Name).Append(" = ").Append(data.Type).AppendLine(".Create(reader.Remaining);");
+                sb.AppendTabs(tabs).Append("callback").Append(data.Name).Append("(datas").Append(data.Name).AppendLine(");");
+                sb.AppendTabs(tabs).Append("reader.TrySkip(datas").Append(data.Name).AppendLine(".TotalLength);");
+            }
+
+            sb.AppendLine("BytesConsumed = _buffer.Length - reader.Remaining.Length;", tabs);
+            sb.AppendLine("}", --tabs);
         }
 
         private void AppendWriteHeader(StringBuilder sb, int tabs)

--- a/src/SbeCodeGenerator/README.md
+++ b/src/SbeCodeGenerator/README.md
@@ -24,10 +24,11 @@ A Roslyn incremental source generator that converts [FIX Simple Binary Encoding]
 ## Quick Example
 
 ```csharp
-// Decode (with groups and varData)
-if (OrderData.TryParse(buffer, out var order, out var variableData))
+// Decode (with groups and varData) — zero-copy via MessageDataReader
+if (OrderData.TryParse(buffer, out var reader))
 {
-    Console.WriteLine($"Order {order.OrderId} @ {order.Price}");
+    Console.WriteLine($"Order {reader.Data.OrderId} @ {reader.Data.Price}");
+    reader.ReadGroups(/* group/varData callbacks */);
 }
 
 // Encode (simple message — no groups)
@@ -43,7 +44,7 @@ OrderBookData.TryEncode(orderBook, buffer, bids, asks, out int bytesWritten);
 ## Features
 
 - **Zero-copy blittable structs** — `[StructLayout(Explicit)]` with `[FieldOffset]`, directly overlay on buffers
-- **`TryParse` / `TryEncode`** — safe decode/encode with group and varData support
+- **`TryParse` / `TryEncode`** — safe decode/encode with zero-copy `MessageDataReader` and group/varData support
 - **Zero-copy decode** — `TryReadBlock<T>` and `ReadBlockRef<T>` read directly from spans
 - **`in` delegate callbacks** — group iteration passes structs by readonly reference (no copies)
 - **Schema evolution** — `TryReadBlock` handles `blockLength` mismatches (forward/backward compat)

--- a/src/SbeCodeGenerator/SbeSourceGenerator.csproj
+++ b/src/SbeCodeGenerator/SbeSourceGenerator.csproj
@@ -11,7 +11,7 @@
 		<IncludeBuildOutput>false</IncludeBuildOutput>
 		<PackageId>SbeSourceGenerator</PackageId>
 		<Title>SBE Source Generator</Title>
-		<Version>0.9.1</Version>
+		<Version>1.0.0</Version>
 		<Authors>Pedro Sakuma</Authors>
 		<Company>Pedro Sakuma</Company>
 		<Product>SBE Source Generator</Product>

--- a/tests/SbeCodeGenerator.IntegrationTests/CarExampleIntegrationTests.cs
+++ b/tests/SbeCodeGenerator.IntegrationTests/CarExampleIntegrationTests.cs
@@ -85,11 +85,11 @@ namespace SbeCodeGenerator.IntegrationTests
             car.SerialNumber = 42;
             car.Engine.Capacity = 1600;
 
-            var success = CarData.TryParse(buffer, out var parsed, out var remaining);
+            var success = CarData.TryParse(buffer, out var parsed);
 
             Assert.True(success);
-            Assert.Equal(42UL, parsed.SerialNumber);
-            Assert.Equal((ushort)1600, parsed.Engine.Capacity);
+            Assert.Equal(42UL, parsed.Data.SerialNumber);
+            Assert.Equal((ushort)1600, parsed.Data.Engine.Capacity);
         }
 
         [Fact]
@@ -270,11 +270,9 @@ namespace SbeCodeGenerator.IntegrationTests
             codeBytes.CopyTo(span.Slice(offset + 4));
             offset += 4 + codeBytes.Length;
 
-            // Parse: directly slice past the fixed fields since the struct size
-            // includes padding from embedded composites
-            var parsedCar = MemoryMarshal.AsRef<CarData>(span);
-            var variableData = span.Slice(CarData.MESSAGE_SIZE);
-            Assert.Equal(42UL, parsedCar.SerialNumber);
+            // Parse: use TryParse on the full buffer to get a reader
+            Assert.True(CarData.TryParse(span.Slice(0, offset), out var parsedCar));
+            Assert.Equal(42UL, parsedCar.Data.SerialNumber);
 
             int fuelCount = 0;
             int perfCount = 0;
@@ -282,7 +280,7 @@ namespace SbeCodeGenerator.IntegrationTests
             string? manufacturer = null;
             string? modelName = null;
 
-            parsedCar.ConsumeVariableLengthSegments(variableData,
+            parsedCar.ReadGroups(
                 callbackFuelFigures: (in CarData.FuelFiguresData fuel) =>
                 {
                     fuelCount++;

--- a/tests/SbeCodeGenerator.IntegrationTests/CrossSchemaIntegrationTests.cs
+++ b/tests/SbeCodeGenerator.IntegrationTests/CrossSchemaIntegrationTests.cs
@@ -51,11 +51,10 @@ public class CrossSchemaIntegrationTests
         var success = Cross.Schema.Common.V0.HeartbeatData.TryParse(
             buffer,
             Cross.Schema.Common.V0.HeartbeatData.MESSAGE_SIZE,
-            out var parsed,
-            out _);
+            out var parsed);
 
         Assert.True(success);
-        Assert.Equal(1234567890123456789UL, parsed.Timestamp);
+        Assert.Equal(1234567890123456789UL, parsed.Data.Timestamp);
     }
 
     [Fact]
@@ -121,16 +120,16 @@ public class CrossSchemaIntegrationTests
         var s1 = Cross.Schema.Common.V0.HeartbeatData.TryParse(
             heartbeatBuffer,
             Cross.Schema.Common.V0.HeartbeatData.MESSAGE_SIZE,
-            out var parsedHb, out _);
+            out var parsedHb);
 
         var s2 = Cross.Schema.Orders.V0.NewOrderData.TryParse(
             orderBuffer,
             Cross.Schema.Orders.V0.NewOrderData.MESSAGE_SIZE,
-            out var parsedOrder, out _);
+            out var parsedOrder);
 
         Assert.True(s1);
         Assert.True(s2);
-        Assert.Equal(100UL, parsedHb.Timestamp);
-        Assert.Equal(200UL, parsedOrder.OrderId);
+        Assert.Equal(100UL, parsedHb.Data.Timestamp);
+        Assert.Equal(200UL, parsedOrder.Data.OrderId);
     }
 }

--- a/tests/SbeCodeGenerator.IntegrationTests/EdgeCaseIntegrationTests.cs
+++ b/tests/SbeCodeGenerator.IntegrationTests/EdgeCaseIntegrationTests.cs
@@ -152,14 +152,14 @@ namespace SbeCodeGenerator.IntegrationTests
             trade.Flags = TradingFlags.Regular | TradingFlags.DarkPool;
             trade.Venue = Venue.Nasdaq;
 
-            Assert.True(TradeData.TryParse(buffer, out var parsed, out _));
-            Assert.Equal(999L, parsed.TradeId);
-            Assert.Equal(42L, parsed.Instrument.InstrumentId);
-            Assert.Equal(15000000L, parsed.Price.Mantissa);
-            Assert.Equal(100L, parsed.Quantity);
-            Assert.Equal(StatusCode.Filled, parsed.Status);
-            Assert.True((parsed.Flags & TradingFlags.DarkPool) != 0);
-            Assert.Equal(Venue.Nasdaq, parsed.Venue);
+            Assert.True(TradeData.TryParse(buffer, out var parsed));
+            Assert.Equal(999L, parsed.Data.TradeId);
+            Assert.Equal(42L, parsed.Data.Instrument.InstrumentId);
+            Assert.Equal(15000000L, parsed.Data.Price.Mantissa);
+            Assert.Equal(100L, parsed.Data.Quantity);
+            Assert.Equal(StatusCode.Filled, parsed.Data.Status);
+            Assert.True((parsed.Data.Flags & TradingFlags.DarkPool) != 0);
+            Assert.Equal(Venue.Nasdaq, parsed.Data.Venue);
         }
 
         [Fact]
@@ -212,13 +212,13 @@ namespace SbeCodeGenerator.IntegrationTests
             md.Status = StatusCode.PartiallyFilled;
             md.Venue = Venue.Bats;
 
-            Assert.True(MarketDataData.TryParse(buffer, out var parsed, out _));
-            Assert.Equal(12345, parsed.SymbolId);
-            Assert.True((parsed.Flags & TradingFlags.PreMarket) != 0);
-            Assert.True((parsed.Flags & TradingFlags.OffExchange) != 0);
-            Assert.True((parsed.Flags & TradingFlags.Regular) == 0);
-            Assert.Equal(StatusCode.PartiallyFilled, parsed.Status);
-            Assert.Equal(Venue.Bats, parsed.Venue);
+            Assert.True(MarketDataData.TryParse(buffer, out var parsed));
+            Assert.Equal(12345, parsed.Data.SymbolId);
+            Assert.True((parsed.Data.Flags & TradingFlags.PreMarket) != 0);
+            Assert.True((parsed.Data.Flags & TradingFlags.OffExchange) != 0);
+            Assert.True((parsed.Data.Flags & TradingFlags.Regular) == 0);
+            Assert.Equal(StatusCode.PartiallyFilled, parsed.Data.Status);
+            Assert.Equal(Venue.Bats, parsed.Data.Venue);
         }
 
         // --- TextMessage (group with only data, no fixed fields) ---
@@ -265,10 +265,9 @@ namespace SbeCodeGenerator.IntegrationTests
             // Parse
             string capturedContent = "";
             string capturedBody = "";
-            var reader = new Edge.Cases.Test.V0.Runtime.SpanReader(span.Slice(TextMessageData.MESSAGE_SIZE, offset - TextMessageData.MESSAGE_SIZE));
-            var parsed = new TextMessageData();
-            parsed.ConsumeVariableLengthSegments(
-                ref reader,
+            Assert.True(TextMessageData.TryParse(span.Slice(0, offset), out var parsedReader));
+            Assert.Equal(42L, parsedReader.Data.MessageId);
+            parsedReader.ReadGroups(
                 (in TextMessageData.AttachmentsData attachments) => { },
                 attachmentContent => { capturedContent = Encoding.UTF8.GetString(attachmentContent.VarData); },
                 body => { capturedBody = Encoding.UTF8.GetString(body.VarData); }

--- a/tests/SbeCodeGenerator.IntegrationTests/FluentEncoderIntegrationTests.cs
+++ b/tests/SbeCodeGenerator.IntegrationTests/FluentEncoderIntegrationTests.cs
@@ -47,15 +47,14 @@ namespace SbeCodeGenerator.IntegrationTests
             Assert.True(bytesWritten > 0);
 
             // Decode and verify
-            Assert.True(Integration.Test.V0.OrderBookData.TryParse(buffer, out var decoded, out var variableData));
-            Assert.Equal(42, decoded.InstrumentId);
+            Assert.True(Integration.Test.V0.OrderBookData.TryParse(buffer, out var decoded));
+            Assert.Equal(42, decoded.Data.InstrumentId);
 
             // Verify groups
             var decodedBids = new List<Integration.Test.V0.OrderBookData.BidsData>();
             var decodedAsks = new List<Integration.Test.V0.OrderBookData.AsksData>();
 
-            decoded.ConsumeVariableLengthSegments(
-                variableData,
+            decoded.ReadGroups(
                 (in Integration.Test.V0.OrderBookData.BidsData bid) => decodedBids.Add(bid),
                 (in Integration.Test.V0.OrderBookData.AsksData ask) => decodedAsks.Add(ask)
             );
@@ -97,13 +96,12 @@ namespace SbeCodeGenerator.IntegrationTests
             Assert.True(bytesWritten > 0);
 
             // Decode and verify
-            Assert.True(Integration.Test.V0.NewOrderData.TryParse(buffer, out var decoded, out var variableData));
-            Assert.Equal(123, decoded.OrderId.Value);
+            Assert.True(Integration.Test.V0.NewOrderData.TryParse(buffer, out var decoded));
+            Assert.Equal(123, decoded.Data.OrderId.Value);
 
             // Verify varData
             string decodedSymbol = "";
-            decoded.ConsumeVariableLengthSegments(
-                variableData,
+            decoded.ReadGroups(
                 symbolData => {
                     decodedSymbol = Encoding.UTF8.GetString(symbolData.VarData.Slice(0, symbolData.Length));
                 }
@@ -186,13 +184,12 @@ namespace SbeCodeGenerator.IntegrationTests
             Assert.True(bytesWritten > Integration.Test.V0.OrderBookData.MESSAGE_SIZE);
 
             // Verify by decoding
-            Assert.True(Integration.Test.V0.OrderBookData.TryParse(buffer, out var decoded, out var variableData));
-            Assert.Equal(99, decoded.InstrumentId);
+            Assert.True(Integration.Test.V0.OrderBookData.TryParse(buffer, out var decoded));
+            Assert.Equal(99, decoded.Data.InstrumentId);
 
             var bidCount = 0;
             var askCount = 0;
-            decoded.ConsumeVariableLengthSegments(
-                variableData,
+            decoded.ReadGroups(
                 (in Integration.Test.V0.OrderBookData.BidsData bid) => bidCount++,
                 (in Integration.Test.V0.OrderBookData.AsksData ask) => askCount++
             );
@@ -244,14 +241,13 @@ namespace SbeCodeGenerator.IntegrationTests
             Assert.True(bytesWritten > 0);
 
             // Decode and verify
-            Assert.True(Integration.Test.V0.OrderBookData.TryParse(buffer, out var decoded, out var variableData));
-            Assert.Equal(123, decoded.InstrumentId);
+            Assert.True(Integration.Test.V0.OrderBookData.TryParse(buffer, out var decoded));
+            Assert.Equal(123, decoded.Data.InstrumentId);
 
             var decodedBids = new List<Integration.Test.V0.OrderBookData.BidsData>();
             var decodedAsks = new List<Integration.Test.V0.OrderBookData.AsksData>();
 
-            decoded.ConsumeVariableLengthSegments(
-                variableData,
+            decoded.ReadGroups(
                 (in Integration.Test.V0.OrderBookData.BidsData bid) => decodedBids.Add(bid),
                 (in Integration.Test.V0.OrderBookData.AsksData ask) => decodedAsks.Add(ask)
             );

--- a/tests/SbeCodeGenerator.IntegrationTests/GeneratorIntegrationTests.cs
+++ b/tests/SbeCodeGenerator.IntegrationTests/GeneratorIntegrationTests.cs
@@ -96,16 +96,16 @@ namespace SbeCodeGenerator.IntegrationTests
             orderRef.OrderType = Integration.Test.V0.OrderType.Market;
 
             // Act
-            var success = Integration.Test.V0.NewOrderData.TryParse(buffer, out var parsedOrder, out var variableData);
+            var success = Integration.Test.V0.NewOrderData.TryParse(buffer, out var parsedOrder);
 
             // Assert
             Assert.True(success);
-            Assert.Equal(0, variableData.Length);
-            Assert.Equal(999, parsedOrder.OrderId.Value);
-            Assert.Equal(50000, parsedOrder.Price.Value);
-            Assert.Equal(100, parsedOrder.Quantity);
-            Assert.Equal(Integration.Test.V0.OrderSide.Sell, parsedOrder.Side);
-            Assert.Equal(Integration.Test.V0.OrderType.Market, parsedOrder.OrderType);
+            Assert.Equal(0, buffer.Length - Integration.Test.V0.NewOrderData.MESSAGE_SIZE);
+            Assert.Equal(999, parsedOrder.Data.OrderId.Value);
+            Assert.Equal(50000, parsedOrder.Data.Price.Value);
+            Assert.Equal(100, parsedOrder.Data.Quantity);
+            Assert.Equal(Integration.Test.V0.OrderSide.Sell, parsedOrder.Data.Side);
+            Assert.Equal(Integration.Test.V0.OrderType.Market, parsedOrder.Data.OrderType);
         }
 
         [Fact]
@@ -185,36 +185,33 @@ namespace SbeCodeGenerator.IntegrationTests
             var success1 = Integration.Test.V0.NewOrderData.TryParse(
                 buffer, 
                 Integration.Test.V0.NewOrderData.MESSAGE_SIZE, 
-                out var parsedMsg1, 
-                out var remaining1);
+                out var parsedMsg1);
             
             Assert.True(success1);
-            Assert.Equal(123, parsedMsg1.OrderId.Value);
-            Assert.Equal(32, remaining1.Length); // 32 bytes remain for variable data
+            Assert.Equal(123, parsedMsg1.Data.OrderId.Value);
+            Assert.Equal(32, buffer.Length - Integration.Test.V0.NewOrderData.MESSAGE_SIZE); // 32 bytes remain for variable data
             
             // Test with larger block length (simulates newer schema with additional fields)
             int extendedBlockLength = Integration.Test.V0.NewOrderData.MESSAGE_SIZE + 16;
             var success2 = Integration.Test.V0.NewOrderData.TryParse(
                 buffer, 
                 extendedBlockLength, 
-                out var parsedMsg2, 
-                out var remaining2);
+                out var parsedMsg2);
             
             Assert.True(success2);
-            Assert.Equal(123, parsedMsg2.OrderId.Value);
-            Assert.Equal(16, remaining2.Length); // 16 bytes remain for variable data
+            Assert.Equal(123, parsedMsg2.Data.OrderId.Value);
+            Assert.Equal(16, buffer.Length - extendedBlockLength); // 16 bytes remain for variable data
             
             // Test with smaller block length (simulates older schema with fewer fields)
             int smallerBlockLength = Integration.Test.V0.NewOrderData.MESSAGE_SIZE - 2;
             var success3 = Integration.Test.V0.NewOrderData.TryParse(
                 buffer, 
                 smallerBlockLength, 
-                out var parsedMsg3, 
-                out var remaining3);
+                out var parsedMsg3);
             
             Assert.True(success3);
-            Assert.Equal(123, parsedMsg3.OrderId.Value);
-            Assert.Equal(34, remaining3.Length); // More bytes remain
+            Assert.Equal(123, parsedMsg3.Data.OrderId.Value);
+            Assert.Equal(34, buffer.Length - smallerBlockLength); // More bytes remain
         }
 
         [Fact]
@@ -230,12 +227,12 @@ namespace SbeCodeGenerator.IntegrationTests
             message.Price = 10050;    // Implicit conversion
             
             // Use the original TryParse method (calls the new one internally with MESSAGE_SIZE)
-            var success = Integration.Test.V0.NewOrderData.TryParse(buffer, out var parsedMsg, out var remaining);
+            var success = Integration.Test.V0.NewOrderData.TryParse(buffer, out var parsedMsg);
             
             Assert.True(success);
-            Assert.Equal(456, parsedMsg.OrderId.Value);
-            Assert.Equal(10050, parsedMsg.Price.Value);
-            Assert.Equal(0, remaining.Length);
+            Assert.Equal(456, parsedMsg.Data.OrderId.Value);
+            Assert.Equal(10050, parsedMsg.Data.Price.Value);
+            Assert.Equal(0, buffer.Length - Integration.Test.V0.NewOrderData.MESSAGE_SIZE);
         }
 
         [Fact]
@@ -376,9 +373,12 @@ namespace SbeCodeGenerator.IntegrationTests
         [Fact]
         public void ConsumeVariableLengthSegments_WithSpanReader_ParsesGroupsCorrectly()
         {
-            // Arrange - Create buffer with GroupSizeEncoding + entries for bids and asks
+            // Arrange - Create buffer with OrderBookData fixed fields + GroupSizeEncoding + entries for bids and asks
             Span<byte> buffer = stackalloc byte[512];
             int offset = 0;
+            
+            // Reserve space for OrderBookData fixed fields
+            offset += Integration.Test.V0.OrderBookData.MESSAGE_SIZE;
             
             // Write bids group header (3 bids)
             ref Integration.Test.V0.GroupSizeEncoding bidsHeader = ref MemoryMarshal.AsRef<Integration.Test.V0.GroupSizeEncoding>(buffer.Slice(offset));
@@ -416,10 +416,9 @@ namespace SbeCodeGenerator.IntegrationTests
             var bidQuantities = new System.Collections.Generic.List<long>();
             var askQuantities = new System.Collections.Generic.List<long>();
             
-            // Create a dummy OrderBookData and call ConsumeVariableLengthSegments
-            var orderBook = new Integration.Test.V0.OrderBookData();
-            orderBook.ConsumeVariableLengthSegments(
-                buffer.Slice(0, offset),
+            // Parse using TryParse and call ReadGroups
+            Assert.True(Integration.Test.V0.OrderBookData.TryParse(buffer.Slice(0, offset), out var orderBookReader));
+            orderBookReader.ReadGroups(
                 (in Integration.Test.V0.OrderBookData.BidsData bid) => { bidPrices.Add(bid.Price.Value); bidQuantities.Add(bid.Quantity); },
                 (in Integration.Test.V0.OrderBookData.AsksData ask) => { askPrices.Add(ask.Price.Value); askQuantities.Add(ask.Quantity); }
             );
@@ -446,9 +445,12 @@ namespace SbeCodeGenerator.IntegrationTests
         [Fact]
         public void ConsumeVariableLengthSegments_WithSpanReader_ParsesDataFieldsCorrectly()
         {
-            // Arrange - Create buffer with VarString8 data
+            // Arrange - Create buffer with NewOrderData fixed fields + VarString8 data
             Span<byte> buffer = stackalloc byte[512];
             int offset = 0;
+            
+            // Reserve space for NewOrderData fixed fields
+            offset += Integration.Test.V0.NewOrderData.MESSAGE_SIZE;
             
             // Write VarString8: length byte + string bytes
             string testSymbol = "AAPL";
@@ -461,9 +463,8 @@ namespace SbeCodeGenerator.IntegrationTests
             // Act
             byte symbolLength = 0;
             string symbolStr = "";
-            var order = new Integration.Test.V0.NewOrderData();
-            order.ConsumeVariableLengthSegments(
-                buffer.Slice(0, offset),
+            Assert.True(Integration.Test.V0.NewOrderData.TryParse(buffer.Slice(0, offset), out var orderReader));
+            orderReader.ReadGroups(
                 symbol => { 
                     symbolLength = symbol.Length;
                     symbolStr = System.Text.Encoding.UTF8.GetString(symbol.VarData);
@@ -485,12 +486,10 @@ namespace SbeCodeGenerator.IntegrationTests
             Span<byte> smallBuffer = stackalloc byte[10]; // Less than MESSAGE_SIZE (26)
             
             // Act
-            var success = Integration.Test.V0.NewOrderData.TryParse(smallBuffer, out var message, out var variableData);
+            var success = Integration.Test.V0.NewOrderData.TryParse(smallBuffer, out var reader);
             
             // Assert
             Assert.False(success);
-            Assert.Equal(default(Integration.Test.V0.NewOrderData), message);
-            Assert.True(variableData.IsEmpty);
         }
 
         [Fact]
@@ -508,16 +507,16 @@ namespace SbeCodeGenerator.IntegrationTests
             orderRef.OrderType = Integration.Test.V0.OrderType.Limit;
             
             // Act
-            var success = Integration.Test.V0.NewOrderData.TryParse(buffer, out var message, out var variableData);
+            var success = Integration.Test.V0.NewOrderData.TryParse(buffer, out var message);
             
             // Assert
             Assert.True(success);
-            Assert.Equal(12345, message.OrderId.Value);
-            Assert.Equal(99999, message.Price.Value);
-            Assert.Equal(500, message.Quantity);
-            Assert.Equal(Integration.Test.V0.OrderSide.Buy, message.Side);
-            Assert.Equal(Integration.Test.V0.OrderType.Limit, message.OrderType);
-            Assert.Equal(16, variableData.Length); // Remaining bytes after MESSAGE_SIZE
+            Assert.Equal(12345, message.Data.OrderId.Value);
+            Assert.Equal(99999, message.Data.Price.Value);
+            Assert.Equal(500, message.Data.Quantity);
+            Assert.Equal(Integration.Test.V0.OrderSide.Buy, message.Data.Side);
+            Assert.Equal(Integration.Test.V0.OrderType.Limit, message.Data.OrderType);
+            Assert.Equal(16, buffer.Length - Integration.Test.V0.NewOrderData.MESSAGE_SIZE); // Remaining bytes after MESSAGE_SIZE
         }
 
         [Fact]
@@ -534,14 +533,14 @@ namespace SbeCodeGenerator.IntegrationTests
             orderRef.Price = 5000;
             
             // Act - Parse with larger block length
-            var success = Integration.Test.V0.NewOrderData.TryParse(buffer, extendedBlockLength, out var message, out var variableData);
+            var success = Integration.Test.V0.NewOrderData.TryParse(buffer, extendedBlockLength, out var message);
             
             // Assert
             Assert.True(success);
-            Assert.Equal(777, message.OrderId.Value);
-            Assert.Equal(5000, message.Price.Value);
+            Assert.Equal(777, message.Data.OrderId.Value);
+            Assert.Equal(5000, message.Data.Price.Value);
             // Variable data should start after the extended block length
-            Assert.Equal(10, variableData.Length);
+            Assert.Equal(10, buffer.Length - extendedBlockLength);
         }
 
         [Fact]
@@ -558,14 +557,14 @@ namespace SbeCodeGenerator.IntegrationTests
             orderRef.Price = 6000;
             
             // Act - Parse with smaller block length
-            var success = Integration.Test.V0.NewOrderData.TryParse(buffer, smallerBlockLength, out var message, out var variableData);
+            var success = Integration.Test.V0.NewOrderData.TryParse(buffer, smallerBlockLength, out var message);
             
             // Assert
             Assert.True(success);
-            Assert.Equal(888, message.OrderId.Value);
-            Assert.Equal(6000, message.Price.Value);
+            Assert.Equal(888, message.Data.OrderId.Value);
+            Assert.Equal(6000, message.Data.Price.Value);
             // Variable data should start at smallerBlockLength, overlapping with message
-            Assert.Equal(Integration.Test.V0.NewOrderData.MESSAGE_SIZE + 20 - smallerBlockLength, variableData.Length);
+            Assert.Equal(Integration.Test.V0.NewOrderData.MESSAGE_SIZE + 20 - smallerBlockLength, buffer.Length - smallerBlockLength);
         }
 
         [Fact]
@@ -579,12 +578,10 @@ namespace SbeCodeGenerator.IntegrationTests
             Span<byte> buffer = stackalloc byte[40]; // Less than blockLength
             
             // Act
-            var success = Integration.Test.V0.NewOrderData.TryParse(buffer, blockLength, out var message, out var variableData);
+            var success = Integration.Test.V0.NewOrderData.TryParse(buffer, blockLength, out var reader);
             
             // Assert
             Assert.False(success);
-            Assert.Equal(default(Integration.Test.V0.NewOrderData), message);
-            Assert.True(variableData.IsEmpty);
         }
 
         [Fact]
@@ -598,28 +595,28 @@ namespace SbeCodeGenerator.IntegrationTests
             Span<byte> buffer = stackalloc byte[10]; // Less than blockLength
             
             // Act
-            var success = Integration.Test.V0.NewOrderData.TryParse(buffer, blockLength, out var message, out var variableData);
+            var success = Integration.Test.V0.NewOrderData.TryParse(buffer, blockLength, out var reader);
             
             // Assert - should fail because buffer is too small for blockLength
             Assert.False(success);
-            Assert.Equal(default(Integration.Test.V0.NewOrderData), message);
-            Assert.True(variableData.IsEmpty);
             
             // Verify that blockLength < MESSAGE_SIZE succeeds (backward compat: partial read)
             int smallBlockLength = 10;
             Span<byte> adequateBuffer = stackalloc byte[10];
-            var partialSuccess = Integration.Test.V0.NewOrderData.TryParse(adequateBuffer, smallBlockLength, out var partialMessage, out var remaining);
+            var partialSuccess = Integration.Test.V0.NewOrderData.TryParse(adequateBuffer, smallBlockLength, out var partialReader);
             Assert.True(partialSuccess);
-            Assert.True(remaining.IsEmpty); // All 10 bytes consumed by blockLength
         }
 
         [Fact]
         public void ConsumeVariableLengthSegments_WithRefSpanReader_ParsesGroupsCorrectly()
         {
-            // Test that the new SpanReader overload works correctly and advances the reader position
-            // Arrange - Create buffer with GroupSizeEncoding + entries for bids and asks
+            // Test that ReadGroups correctly parses groups from the buffer
+            // Arrange - Create buffer with OrderBookData fixed fields + GroupSizeEncoding + entries for bids and asks
             Span<byte> buffer = stackalloc byte[512];
             int offset = 0;
+            
+            // Reserve space for OrderBookData fixed fields
+            offset += Integration.Test.V0.OrderBookData.MESSAGE_SIZE;
             
             // Write bids group header (3 bids)
             ref Integration.Test.V0.GroupSizeEncoding bidsHeader = ref MemoryMarshal.AsRef<Integration.Test.V0.GroupSizeEncoding>(buffer.Slice(offset));
@@ -651,7 +648,7 @@ namespace SbeCodeGenerator.IntegrationTests
                 offset += Integration.Test.V0.OrderBookData.AsksData.MESSAGE_SIZE;
             }
             
-            // Add extra data after the variable length segments to verify reader position advancement
+            // Add extra data after the variable length segments
             buffer[offset++] = 0xFF;
             buffer[offset++] = 0xAA;
             
@@ -661,11 +658,9 @@ namespace SbeCodeGenerator.IntegrationTests
             var bidQuantities = new System.Collections.Generic.List<long>();
             var askQuantities = new System.Collections.Generic.List<long>();
             
-            // Create SpanReader and use the new overload
-            var reader = new Integration.Test.V0.Runtime.SpanReader(buffer.Slice(0, offset));
-            var orderBook = new Integration.Test.V0.OrderBookData();
-            orderBook.ConsumeVariableLengthSegments(
-                ref reader,
+            // Parse using TryParse and call ReadGroups
+            Assert.True(Integration.Test.V0.OrderBookData.TryParse(buffer.Slice(0, offset), out var orderBookReader));
+            orderBookReader.ReadGroups(
                 (in Integration.Test.V0.OrderBookData.BidsData bid) => { bidPrices.Add(bid.Price.Value); bidQuantities.Add(bid.Quantity); },
                 (in Integration.Test.V0.OrderBookData.AsksData ask) => { askPrices.Add(ask.Price.Value); askQuantities.Add(ask.Quantity); }
             );
@@ -687,26 +682,19 @@ namespace SbeCodeGenerator.IntegrationTests
             Assert.Equal(2010, askPrices[1]);
             Assert.Equal(200, askQuantities[0]);
             Assert.Equal(201, askQuantities[1]);
-            
-            // Verify reader position was advanced to the extra data
-            Assert.Equal(2, reader.RemainingBytes);
-            Assert.True(reader.TryReadBytes(1, out var extraByte1));
-            Assert.Equal(0xFF, extraByte1[0]);
-            Assert.True(reader.TryReadBytes(1, out var extraByte2));
-            Assert.Equal(0xAA, extraByte2[0]);
-            Assert.Equal(0, reader.RemainingBytes);
         }
 
         [Fact]
         public void ConsumeVariableLengthSegments_WithRefSpanReader_ParsesDataFieldsCorrectly()
         {
-            // Test that the new SpanReader overload works with data fields
-            // Note: Data fields use reader.Remaining without advancing the reader position
-            // This is expected behavior since data fields consume all remaining bytes
+            // Test that ReadGroups works with data fields
             
-            // Arrange - Create buffer with VarString8 data
+            // Arrange - Create buffer with NewOrderData fixed fields + VarString8 data
             Span<byte> buffer = stackalloc byte[512];
             int offset = 0;
+            
+            // Reserve space for NewOrderData fixed fields
+            offset += Integration.Test.V0.NewOrderData.MESSAGE_SIZE;
             
             // Write VarString8: length byte + string bytes
             string testSymbol = "AAPL";
@@ -719,10 +707,8 @@ namespace SbeCodeGenerator.IntegrationTests
             // Act
             byte symbolLength = 0;
             string symbolStr = "";
-            var reader = new Integration.Test.V0.Runtime.SpanReader(buffer.Slice(0, offset));
-            var order = new Integration.Test.V0.NewOrderData();
-            order.ConsumeVariableLengthSegments(
-                ref reader,
+            Assert.True(Integration.Test.V0.NewOrderData.TryParse(buffer.Slice(0, offset), out var orderReader));
+            orderReader.ReadGroups(
                 symbol => { 
                     symbolLength = symbol.Length;
                     symbolStr = System.Text.Encoding.UTF8.GetString(symbol.VarData);
@@ -732,9 +718,6 @@ namespace SbeCodeGenerator.IntegrationTests
             // Assert
             Assert.Equal((byte)4, symbolLength);
             Assert.Equal("AAPL", symbolStr);
-            
-            // Verify the reader was advanced past the data segment
-            Assert.Equal(0, reader.RemainingBytes);
         }
     }
 }

--- a/tests/SbeCodeGenerator.IntegrationTests/GroupAndVarDataEncodingTests.cs
+++ b/tests/SbeCodeGenerator.IntegrationTests/GroupAndVarDataEncodingTests.cs
@@ -36,8 +36,8 @@ namespace SbeCodeGenerator.IntegrationTests
             Assert.True(bytesWritten > 0);
             
             // Decode and verify
-            Assert.True(Integration.Test.V0.OrderBookData.TryParse(buffer, out var decoded, out var variableData));
-            Assert.Equal(42, decoded.InstrumentId);
+            Assert.True(Integration.Test.V0.OrderBookData.TryParse(buffer, out var decoded));
+            Assert.Equal(42, decoded.Data.InstrumentId);
         }
 
         [Fact]
@@ -70,14 +70,13 @@ namespace SbeCodeGenerator.IntegrationTests
             Assert.True(bytesWritten > 0);
             
             // Decode and verify both groups
-            Assert.True(Integration.Test.V0.OrderBookData.TryParse(buffer, out var decoded, out var variableData));
-            Assert.Equal(99, decoded.InstrumentId);
+            Assert.True(Integration.Test.V0.OrderBookData.TryParse(buffer, out var decoded));
+            Assert.Equal(99, decoded.Data.InstrumentId);
             
             var decodedBids = new List<Integration.Test.V0.OrderBookData.BidsData>();
             var decodedAsks = new List<Integration.Test.V0.OrderBookData.AsksData>();
             
-            decoded.ConsumeVariableLengthSegments(
-                variableData,
+            decoded.ReadGroups(
                 (in Integration.Test.V0.OrderBookData.BidsData bid) => decodedBids.Add(bid),
                 (in Integration.Test.V0.OrderBookData.AsksData ask) => decodedAsks.Add(ask)
             );
@@ -143,12 +142,11 @@ namespace SbeCodeGenerator.IntegrationTests
             Assert.True(bytesWritten > 0);
             
             // Decode and verify
-            Assert.True(Integration.Test.V0.NewOrderData.TryParse(buffer, out var decoded, out var variableData));
-            Assert.Equal(123, decoded.OrderId.Value);
+            Assert.True(Integration.Test.V0.NewOrderData.TryParse(buffer, out var decoded));
+            Assert.Equal(123, decoded.Data.OrderId.Value);
             
             string decodedSymbol = "";
-            decoded.ConsumeVariableLengthSegments(
-                variableData,
+            decoded.ReadGroups(
                 symbolData => {
                     decodedSymbol = Encoding.UTF8.GetString(symbolData.VarData.Slice(0, symbolData.Length));
                 }
@@ -279,15 +277,14 @@ namespace SbeCodeGenerator.IntegrationTests
             Assert.True(totalBytesWritten > 0);
 
             // Decode the fixed part
-            Assert.True(Integration.Test.V0.OrderBookData.TryParse(buffer, out var decodedMessage, out var variableData));
-            Assert.Equal(42, decodedMessage.InstrumentId);
+            Assert.True(Integration.Test.V0.OrderBookData.TryParse(buffer, out var decodedMessage));
+            Assert.Equal(42, decodedMessage.Data.InstrumentId);
 
-            // Decode the groups using ConsumeVariableLengthSegments
+            // Decode the groups using ReadGroups
             var decodedBids = new List<Integration.Test.V0.OrderBookData.BidsData>();
             var decodedAsks = new List<Integration.Test.V0.OrderBookData.AsksData>();
 
-            decodedMessage.ConsumeVariableLengthSegments(
-                variableData,
+            decodedMessage.ReadGroups(
                 (in Integration.Test.V0.OrderBookData.BidsData bid) => decodedBids.Add(bid),
                 (in Integration.Test.V0.OrderBookData.AsksData ask) => decodedAsks.Add(ask)
             );
@@ -340,16 +337,15 @@ namespace SbeCodeGenerator.IntegrationTests
             Assert.True(bytesWritten > 0);
 
             // Decode the fixed part
-            Assert.True(Integration.Test.V0.NewOrderData.TryParse(buffer, out var decodedOrder, out var variableData));
-            Assert.Equal(123, decodedOrder.OrderId.Value);
-            Assert.Equal(9950, decodedOrder.Price.Value);
-            Assert.Equal(100, decodedOrder.Quantity);
+            Assert.True(Integration.Test.V0.NewOrderData.TryParse(buffer, out var decodedOrder));
+            Assert.Equal(123, decodedOrder.Data.OrderId.Value);
+            Assert.Equal(9950, decodedOrder.Data.Price.Value);
+            Assert.Equal(100, decodedOrder.Data.Quantity);
 
-            // Decode the varData using ConsumeVariableLengthSegments
+            // Decode the varData using ReadGroups
             string? decodedSymbol = null;
             byte symbolLength = 0;
-            decodedOrder.ConsumeVariableLengthSegments(
-                variableData,
+            decodedOrder.ReadGroups(
                 symbolData => {
                     symbolLength = symbolData.Length;
                     // VarData contains the actual data, but we need to use Length to know how much to read

--- a/tests/SbeCodeGenerator.IntegrationTests/OptionalFieldsIntegrationTests.cs
+++ b/tests/SbeCodeGenerator.IntegrationTests/OptionalFieldsIntegrationTests.cs
@@ -30,13 +30,13 @@ namespace SbeCodeGenerator.IntegrationTests
             Assert.Equal(SimpleOptionalData.MESSAGE_SIZE, bytesWritten);
 
             // Act - Decode
-            bool decodeResult = SimpleOptionalData.TryParse(buffer, out var decoded, out _);
+            bool decodeResult = SimpleOptionalData.TryParse(buffer, out var decoded);
 
             // Assert decoding succeeded and values match
             Assert.True(decodeResult);
-            Assert.Equal(original.Id, decoded.Id);
-            Assert.Equal(456, decoded.OptionalValue);
-            Assert.NotNull(decoded.OptionalValue);
+            Assert.Equal(original.Id, decoded.Data.Id);
+            Assert.Equal(456, decoded.Data.OptionalValue);
+            Assert.NotNull(decoded.Data.OptionalValue);
         }
 
         [Fact]
@@ -59,12 +59,12 @@ namespace SbeCodeGenerator.IntegrationTests
             Assert.Equal(SimpleOptionalData.MESSAGE_SIZE, bytesWritten);
 
             // Act - Decode
-            bool decodeResult = SimpleOptionalData.TryParse(buffer, out var decoded, out _);
+            bool decodeResult = SimpleOptionalData.TryParse(buffer, out var decoded);
 
             // Assert decoding succeeded and value is null
             Assert.True(decodeResult);
-            Assert.Equal(original.Id, decoded.Id);
-            Assert.Null(decoded.OptionalValue);
+            Assert.Equal(original.Id, decoded.Data.Id);
+            Assert.Null(decoded.Data.OptionalValue);
         }
 
         [Fact]
@@ -86,11 +86,11 @@ namespace SbeCodeGenerator.IntegrationTests
             Assert.True(encodeResult);
 
             // Act - Decode
-            bool decodeResult = SimpleOptionalData.TryParse(buffer, out var decoded, out _);
+            bool decodeResult = SimpleOptionalData.TryParse(buffer, out var decoded);
 
             // Assert decoding succeeded and value is null (or could be treated as uninitialized)
             Assert.True(decodeResult);
-            Assert.Equal(original.Id, decoded.Id);
+            Assert.Equal(original.Id, decoded.Data.Id);
             // The behavior when not set depends on whether the struct is zero-initialized
             // In practice, this should either be null or the default value
         }
@@ -114,9 +114,9 @@ namespace SbeCodeGenerator.IntegrationTests
             Assert.Equal(SimpleOptionalData.MESSAGE_SIZE, bytesWritten);
 
             // Verify round-trip
-            SimpleOptionalData.TryParse(buffer, out var decoded, out _);
-            Assert.Equal(message.Id, decoded.Id);
-            Assert.Equal(222, decoded.OptionalValue);
+            SimpleOptionalData.TryParse(buffer, out var decoded);
+            Assert.Equal(message.Id, decoded.Data.Id);
+            Assert.Equal(222, decoded.Data.OptionalValue);
         }
 
         [Fact]
@@ -140,9 +140,9 @@ namespace SbeCodeGenerator.IntegrationTests
             Assert.Equal(SimpleOptionalData.MESSAGE_SIZE, writer.BytesWritten);
 
             // Verify round-trip
-            SimpleOptionalData.TryParse(buffer, out var decoded, out _);
-            Assert.Equal(message.Id, decoded.Id);
-            Assert.Null(decoded.OptionalValue);
+            SimpleOptionalData.TryParse(buffer, out var decoded);
+            Assert.Equal(message.Id, decoded.Data.Id);
+            Assert.Null(decoded.Data.OptionalValue);
         }
 
         [Fact]
@@ -177,12 +177,12 @@ namespace SbeCodeGenerator.IntegrationTests
                 Assert.True(encodeResult, $"Failed to encode test case with Id={testCase.Id}");
 
                 // Act - Decode
-                bool decodeResult = SimpleOptionalData.TryParse(buffer, out var decoded, out _);
+                bool decodeResult = SimpleOptionalData.TryParse(buffer, out var decoded);
 
                 // Assert decoding and value preservation
                 Assert.True(decodeResult, $"Failed to decode test case with Id={testCase.Id}");
-                Assert.Equal(testCase.Id, decoded.Id);
-                Assert.Equal(testCase.OptionalValue, decoded.OptionalValue);
+                Assert.Equal(testCase.Id, decoded.Data.Id);
+                Assert.Equal(testCase.OptionalValue, decoded.Data.OptionalValue);
             }
         }
 
@@ -237,22 +237,22 @@ namespace SbeCodeGenerator.IntegrationTests
             message.SetOptionalValue(100);
             var buffer1 = new byte[SimpleOptionalData.MESSAGE_SIZE];
             message.TryEncode(buffer1, out _);
-            SimpleOptionalData.TryParse(buffer1, out var decoded1, out _);
-            Assert.Equal(100, decoded1.OptionalValue);
+            SimpleOptionalData.TryParse(buffer1, out var decoded1);
+            Assert.Equal(100, decoded1.Data.OptionalValue);
 
             // Act & Assert - Set to null
             message.SetOptionalValue(null);
             var buffer2 = new byte[SimpleOptionalData.MESSAGE_SIZE];
             message.TryEncode(buffer2, out _);
-            SimpleOptionalData.TryParse(buffer2, out var decoded2, out _);
-            Assert.Null(decoded2.OptionalValue);
+            SimpleOptionalData.TryParse(buffer2, out var decoded2);
+            Assert.Null(decoded2.Data.OptionalValue);
 
             // Act & Assert - Set to different value
             message.SetOptionalValue(200);
             var buffer3 = new byte[SimpleOptionalData.MESSAGE_SIZE];
             message.TryEncode(buffer3, out _);
-            SimpleOptionalData.TryParse(buffer3, out var decoded3, out _);
-            Assert.Equal(200, decoded3.OptionalValue);
+            SimpleOptionalData.TryParse(buffer3, out var decoded3);
+            Assert.Equal(200, decoded3.Data.OptionalValue);
         }
 
         [Fact]
@@ -279,19 +279,19 @@ namespace SbeCodeGenerator.IntegrationTests
             Assert.Equal(AllOptionalTypesData.MESSAGE_SIZE, bytesWritten);
 
             // Act - Decode
-            bool decodeResult = AllOptionalTypesData.TryParse(buffer, out var decoded, out _);
+            bool decodeResult = AllOptionalTypesData.TryParse(buffer, out var decoded);
 
             // Assert decoding succeeded and all values match
             Assert.True(decodeResult);
-            Assert.Equal(original.Id, decoded.Id);
-            Assert.Equal(sbyte.MaxValue, decoded.OptInt8);
-            Assert.Equal(short.MaxValue, decoded.OptInt16);
-            Assert.Equal(int.MaxValue, decoded.OptInt32);
-            Assert.Equal(long.MaxValue, decoded.OptInt64);
-            Assert.Equal((byte)(byte.MaxValue - 1), decoded.OptUInt8);
-            Assert.Equal((ushort)(ushort.MaxValue - 1), decoded.OptUInt16);
-            Assert.Equal(uint.MaxValue - 1, decoded.OptUInt32);
-            Assert.Equal(ulong.MaxValue - 1, decoded.OptUInt64);
+            Assert.Equal(original.Id, decoded.Data.Id);
+            Assert.Equal(sbyte.MaxValue, decoded.Data.OptInt8);
+            Assert.Equal(short.MaxValue, decoded.Data.OptInt16);
+            Assert.Equal(int.MaxValue, decoded.Data.OptInt32);
+            Assert.Equal(long.MaxValue, decoded.Data.OptInt64);
+            Assert.Equal((byte)(byte.MaxValue - 1), decoded.Data.OptUInt8);
+            Assert.Equal((ushort)(ushort.MaxValue - 1), decoded.Data.OptUInt16);
+            Assert.Equal(uint.MaxValue - 1, decoded.Data.OptUInt32);
+            Assert.Equal(ulong.MaxValue - 1, decoded.Data.OptUInt64);
         }
 
         [Fact]
@@ -318,19 +318,19 @@ namespace SbeCodeGenerator.IntegrationTests
             Assert.Equal(AllOptionalTypesData.MESSAGE_SIZE, bytesWritten);
 
             // Act - Decode
-            bool decodeResult = AllOptionalTypesData.TryParse(buffer, out var decoded, out _);
+            bool decodeResult = AllOptionalTypesData.TryParse(buffer, out var decoded);
 
             // Assert decoding succeeded and all values are null
             Assert.True(decodeResult);
-            Assert.Equal(original.Id, decoded.Id);
-            Assert.Null(decoded.OptInt8);
-            Assert.Null(decoded.OptInt16);
-            Assert.Null(decoded.OptInt32);
-            Assert.Null(decoded.OptInt64);
-            Assert.Null(decoded.OptUInt8);
-            Assert.Null(decoded.OptUInt16);
-            Assert.Null(decoded.OptUInt32);
-            Assert.Null(decoded.OptUInt64);
+            Assert.Equal(original.Id, decoded.Data.Id);
+            Assert.Null(decoded.Data.OptInt8);
+            Assert.Null(decoded.Data.OptInt16);
+            Assert.Null(decoded.Data.OptInt32);
+            Assert.Null(decoded.Data.OptInt64);
+            Assert.Null(decoded.Data.OptUInt8);
+            Assert.Null(decoded.Data.OptUInt16);
+            Assert.Null(decoded.Data.OptUInt32);
+            Assert.Null(decoded.Data.OptUInt64);
         }
 
         [Fact]
@@ -356,19 +356,19 @@ namespace SbeCodeGenerator.IntegrationTests
             Assert.True(encodeResult);
 
             // Act - Decode
-            bool decodeResult = AllOptionalTypesData.TryParse(buffer, out var decoded, out _);
+            bool decodeResult = AllOptionalTypesData.TryParse(buffer, out var decoded);
 
             // Assert decoding succeeded and values match
             Assert.True(decodeResult);
-            Assert.Equal(original.Id, decoded.Id);
-            Assert.Equal((sbyte)10, decoded.OptInt8);
-            Assert.Null(decoded.OptInt16);
-            Assert.Equal(1000, decoded.OptInt32);
-            Assert.Null(decoded.OptInt64);
-            Assert.Null(decoded.OptUInt8);
-            Assert.Equal((ushort)200, decoded.OptUInt16);
-            Assert.Null(decoded.OptUInt32);
-            Assert.Equal((ulong)3000, decoded.OptUInt64);
+            Assert.Equal(original.Id, decoded.Data.Id);
+            Assert.Equal((sbyte)10, decoded.Data.OptInt8);
+            Assert.Null(decoded.Data.OptInt16);
+            Assert.Equal(1000, decoded.Data.OptInt32);
+            Assert.Null(decoded.Data.OptInt64);
+            Assert.Null(decoded.Data.OptUInt8);
+            Assert.Equal((ushort)200, decoded.Data.OptUInt16);
+            Assert.Null(decoded.Data.OptUInt32);
+            Assert.Equal((ulong)3000, decoded.Data.OptUInt64);
         }
 
         [Fact]
@@ -389,17 +389,17 @@ namespace SbeCodeGenerator.IntegrationTests
 
             // Act - Encode and decode
             original.TryEncode(buffer, out _);
-            AllOptionalTypesData.TryParse(buffer, out var decoded, out _);
+            AllOptionalTypesData.TryParse(buffer, out var decoded);
 
             // Assert all values are preserved (not null)
-            Assert.Equal((sbyte)-127, decoded.OptInt8);
-            Assert.Equal((short)-32767, decoded.OptInt16);
-            Assert.Equal(-2147483647, decoded.OptInt32);
-            Assert.Equal(-9223372036854775807L, decoded.OptInt64);
-            Assert.Equal((byte)254, decoded.OptUInt8);
-            Assert.Equal((ushort)65534, decoded.OptUInt16);
-            Assert.Equal((uint)4294967294, decoded.OptUInt32);
-            Assert.Equal((ulong)18446744073709551614, decoded.OptUInt64);
+            Assert.Equal((sbyte)-127, decoded.Data.OptInt8);
+            Assert.Equal((short)-32767, decoded.Data.OptInt16);
+            Assert.Equal(-2147483647, decoded.Data.OptInt32);
+            Assert.Equal(-9223372036854775807L, decoded.Data.OptInt64);
+            Assert.Equal((byte)254, decoded.Data.OptUInt8);
+            Assert.Equal((ushort)65534, decoded.Data.OptUInt16);
+            Assert.Equal((uint)4294967294, decoded.Data.OptUInt32);
+            Assert.Equal((ulong)18446744073709551614, decoded.Data.OptUInt64);
         }
     }
 }

--- a/tests/SbeCodeGenerator.IntegrationTests/SpanWriterIntegrationTests.cs
+++ b/tests/SbeCodeGenerator.IntegrationTests/SpanWriterIntegrationTests.cs
@@ -34,15 +34,15 @@ namespace SbeCodeGenerator.IntegrationTests
             Assert.Equal(NewOrderData.MESSAGE_SIZE, bytesWritten);
 
             // Act - Decode
-            bool decodeResult = NewOrderData.TryParse(buffer, out var decoded, out _);
+            bool decodeResult = NewOrderData.TryParse(buffer, out var decoded);
 
             // Assert decoding succeeded and values match
             Assert.True(decodeResult);
-            Assert.Equal(original.OrderId, decoded.OrderId);
-            Assert.Equal(original.Price, decoded.Price);
-            Assert.Equal(original.Quantity, decoded.Quantity);
-            Assert.Equal(original.Side, decoded.Side);
-            Assert.Equal(original.OrderType, decoded.OrderType);
+            Assert.Equal(original.OrderId, decoded.Data.OrderId);
+            Assert.Equal(original.Price, decoded.Data.Price);
+            Assert.Equal(original.Quantity, decoded.Data.Quantity);
+            Assert.Equal(original.Side, decoded.Data.Side);
+            Assert.Equal(original.OrderType, decoded.Data.OrderType);
         }
 
         [Fact]
@@ -90,8 +90,8 @@ namespace SbeCodeGenerator.IntegrationTests
             Assert.Equal(NewOrderData.MESSAGE_SIZE, bytesWritten);
 
             // Verify round-trip
-            NewOrderData.TryParse(buffer, out var decoded, out _);
-            Assert.Equal(message.OrderId, decoded.OrderId);
+            NewOrderData.TryParse(buffer, out var decoded);
+            Assert.Equal(message.OrderId, decoded.Data.OrderId);
         }
 
         [Fact]
@@ -141,10 +141,10 @@ namespace SbeCodeGenerator.IntegrationTests
             Assert.Equal(NewOrderData.MESSAGE_SIZE, writer.BytesWritten);
 
             // Verify round-trip
-            NewOrderData.TryParse(buffer, out var decoded, out _);
-            Assert.Equal(message.OrderId, decoded.OrderId);
-            Assert.Equal(message.Price, decoded.Price);
-            Assert.Equal(message.Quantity, decoded.Quantity);
+            NewOrderData.TryParse(buffer, out var decoded);
+            Assert.Equal(message.OrderId, decoded.Data.OrderId);
+            Assert.Equal(message.Price, decoded.Data.Price);
+            Assert.Equal(message.Quantity, decoded.Data.Quantity);
         }
 
         [Fact]
@@ -170,15 +170,15 @@ namespace SbeCodeGenerator.IntegrationTests
                 Assert.True(encodeResult);
 
                 // Act - Decode
-                bool decodeResult = NewOrderData.TryParse(buffer, out var decoded, out _);
+                bool decodeResult = NewOrderData.TryParse(buffer, out var decoded);
 
                 // Assert decoding and value preservation
                 Assert.True(decodeResult);
-                Assert.Equal(original.OrderId, decoded.OrderId);
-                Assert.Equal(original.Price, decoded.Price);
-                Assert.Equal(original.Quantity, decoded.Quantity);
-                Assert.Equal(original.Side, decoded.Side);
-                Assert.Equal(original.OrderType, decoded.OrderType);
+                Assert.Equal(original.OrderId, decoded.Data.OrderId);
+                Assert.Equal(original.Price, decoded.Data.Price);
+                Assert.Equal(original.Quantity, decoded.Data.Quantity);
+                Assert.Equal(original.Side, decoded.Data.Side);
+                Assert.Equal(original.OrderType, decoded.Data.OrderType);
             }
         }
 
@@ -235,11 +235,11 @@ namespace SbeCodeGenerator.IntegrationTests
             Assert.Equal(OrderBookData.MESSAGE_SIZE, bytesWritten);
 
             // Act - Decode
-            bool decodeResult = OrderBookData.TryParse(buffer, out var decoded, out _);
+            bool decodeResult = OrderBookData.TryParse(buffer, out var decoded);
 
             // Assert decoding
             Assert.True(decodeResult);
-            Assert.Equal(original.InstrumentId, decoded.InstrumentId);
+            Assert.Equal(original.InstrumentId, decoded.Data.InstrumentId);
         }
 
         [Fact]

--- a/tests/SbeCodeGenerator.IntegrationTests/VersioningIntegrationTests.cs
+++ b/tests/SbeCodeGenerator.IntegrationTests/VersioningIntegrationTests.cs
@@ -134,10 +134,10 @@ namespace SbeCodeGenerator.IntegrationTests
             v0Setup.OrderId = 123;
             v0Setup.Price = 9900;
             
-            var v0Success = V0.EvolvingOrderData.TryParse(v0Buffer, out var v0Parsed, out _);
+            var v0Success = V0.EvolvingOrderData.TryParse(v0Buffer, out var v0Parsed);
             Assert.True(v0Success);
-            Assert.Equal(123, v0Parsed.OrderId.Value);
-            Assert.Equal(9900, v0Parsed.Price.Value);
+            Assert.Equal(123, v0Parsed.Data.OrderId.Value);
+            Assert.Equal(9900, v0Parsed.Data.Price.Value);
             
             // Test that TryParse works for V1
             Span<byte> v1Buffer = stackalloc byte[V1.EvolvingOrderData.MESSAGE_SIZE];
@@ -146,10 +146,10 @@ namespace SbeCodeGenerator.IntegrationTests
             v1Setup.Price = 10000;
             v1Setup.Quantity = 200;
             
-            var v1Success = V1.EvolvingOrderData.TryParse(v1Buffer, out var v1Parsed, out _);
+            var v1Success = V1.EvolvingOrderData.TryParse(v1Buffer, out var v1Parsed);
             Assert.True(v1Success);
-            Assert.Equal(456, v1Parsed.OrderId.Value);
-            Assert.Equal(200, v1Parsed.Quantity);
+            Assert.Equal(456, v1Parsed.Data.OrderId.Value);
+            Assert.Equal(200, v1Parsed.Data.Quantity);
             
             // Test that TryParse works for V2
             Span<byte> v2Buffer = stackalloc byte[V2.EvolvingOrderData.MESSAGE_SIZE];
@@ -159,11 +159,11 @@ namespace SbeCodeGenerator.IntegrationTests
             v2Setup.Quantity = 300;
             v2Setup.Side = 1;
             
-            var v2Success = V2.EvolvingOrderData.TryParse(v2Buffer, out var v2Parsed, out _);
+            var v2Success = V2.EvolvingOrderData.TryParse(v2Buffer, out var v2Parsed);
             Assert.True(v2Success);
-            Assert.Equal(789, v2Parsed.OrderId.Value);
-            Assert.Equal(300, v2Parsed.Quantity);
-            Assert.Equal(1, v2Parsed.Side);
+            Assert.Equal(789, v2Parsed.Data.OrderId.Value);
+            Assert.Equal(300, v2Parsed.Data.Quantity);
+            Assert.Equal(1, v2Parsed.Data.Side);
         }
 
         [Fact]

--- a/tests/SbeCodeGenerator.Tests/Snapshots/MessagesCodeGenerator.Message.Quote.verified.txt
+++ b/tests/SbeCodeGenerator.Tests/Snapshots/MessagesCodeGenerator.Message.Quote.verified.txt
@@ -50,26 +50,32 @@ public partial struct QuoteData
 	[FieldOffset(24)]
 	public long AskQuantity;
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public static bool TryParse(ReadOnlySpan<byte> buffer, out QuoteData message, out ReadOnlySpan<byte> variableData)
+	public static bool TryParse(ReadOnlySpan<byte> buffer, out QuoteDataReader reader)
 	{
-		return TryParse(buffer, BLOCK_LENGTH, out message, out variableData);
+		return TryParse(buffer, BLOCK_LENGTH, out reader);
 	}
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public static bool TryParse(ReadOnlySpan<byte> buffer, int blockLength, out QuoteData message, out ReadOnlySpan<byte> variableData)
+	public static bool TryParse(ReadOnlySpan<byte> buffer, int blockLength, out QuoteDataReader reader)
 	{
-		var reader = new SpanReader(buffer);
-		if (!reader.TryReadBlock<QuoteData>(blockLength, out message))
+		if (buffer.Length < blockLength)
 		{
-			variableData = default;
+			reader = default;
 			return false;
 		}
-		variableData = reader.Remaining;
+		reader = new QuoteDataReader(buffer, blockLength);
 		return true;
 	}
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public static bool TryParseWithReader(ref SpanReader reader, int blockLength, out QuoteData message)
+	public static bool TryParseWithReader(ref SpanReader reader, int blockLength, out QuoteDataReader messageReader)
 	{
-		return reader.TryReadBlock<QuoteData>(blockLength, out message);
+		var remaining = reader.Remaining;
+		if (remaining.Length < blockLength)
+		{
+			messageReader = default;
+			return false;
+		}
+		messageReader = new QuoteDataReader(remaining, blockLength);
+		return true;
 	}
 	/// <summary>
 	/// Encodes this Quote message to the provided buffer.
@@ -133,4 +139,33 @@ public partial struct QuoteData
 		header.Version = 0;
 		return MessageHeader.MESSAGE_SIZE;
 	}
+}
+
+/// <summary>
+/// Zero-copy reader for QuoteData messages.
+/// Provides direct access to the message data in the underlying buffer without copying.
+/// </summary>
+public ref struct QuoteDataReader
+{
+	private readonly ReadOnlySpan<byte> _buffer;
+	private readonly int _blockLength;
+	
+	/// <summary>
+	/// Total bytes consumed from the buffer (block + variable-length data).
+	/// Updated after ReadGroups is called for messages with groups or varData.
+	/// </summary>
+	public int BytesConsumed { get; private set; }
+	
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	internal QuoteDataReader(ReadOnlySpan<byte> buffer, int blockLength)
+	{
+		_buffer = buffer;
+		_blockLength = blockLength;
+		BytesConsumed = blockLength;
+	}
+	
+	/// <summary>
+	/// Gets a readonly reference to the QuoteData directly in the buffer (zero-copy).
+	/// </summary>
+	public ref readonly QuoteData Data => ref Unsafe.As<byte, QuoteData>(ref MemoryMarshal.GetReference(_buffer));
 }

--- a/tests/SbeCodeGenerator.Tests/Snapshots/MessagesCodeGenerator.Message.Trade.verified.txt
+++ b/tests/SbeCodeGenerator.Tests/Snapshots/MessagesCodeGenerator.Message.Trade.verified.txt
@@ -50,26 +50,32 @@ public partial struct TradeData
 	[FieldOffset(24)]
 	public Side Side;
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public static bool TryParse(ReadOnlySpan<byte> buffer, out TradeData message, out ReadOnlySpan<byte> variableData)
+	public static bool TryParse(ReadOnlySpan<byte> buffer, out TradeDataReader reader)
 	{
-		return TryParse(buffer, BLOCK_LENGTH, out message, out variableData);
+		return TryParse(buffer, BLOCK_LENGTH, out reader);
 	}
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public static bool TryParse(ReadOnlySpan<byte> buffer, int blockLength, out TradeData message, out ReadOnlySpan<byte> variableData)
+	public static bool TryParse(ReadOnlySpan<byte> buffer, int blockLength, out TradeDataReader reader)
 	{
-		var reader = new SpanReader(buffer);
-		if (!reader.TryReadBlock<TradeData>(blockLength, out message))
+		if (buffer.Length < blockLength)
 		{
-			variableData = default;
+			reader = default;
 			return false;
 		}
-		variableData = reader.Remaining;
+		reader = new TradeDataReader(buffer, blockLength);
 		return true;
 	}
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public static bool TryParseWithReader(ref SpanReader reader, int blockLength, out TradeData message)
+	public static bool TryParseWithReader(ref SpanReader reader, int blockLength, out TradeDataReader messageReader)
 	{
-		return reader.TryReadBlock<TradeData>(blockLength, out message);
+		var remaining = reader.Remaining;
+		if (remaining.Length < blockLength)
+		{
+			messageReader = default;
+			return false;
+		}
+		messageReader = new TradeDataReader(remaining, blockLength);
+		return true;
 	}
 	/// <summary>
 	/// Encodes this Trade message to the provided buffer.
@@ -133,4 +139,33 @@ public partial struct TradeData
 		header.Version = 0;
 		return MessageHeader.MESSAGE_SIZE;
 	}
+}
+
+/// <summary>
+/// Zero-copy reader for TradeData messages.
+/// Provides direct access to the message data in the underlying buffer without copying.
+/// </summary>
+public ref struct TradeDataReader
+{
+	private readonly ReadOnlySpan<byte> _buffer;
+	private readonly int _blockLength;
+	
+	/// <summary>
+	/// Total bytes consumed from the buffer (block + variable-length data).
+	/// Updated after ReadGroups is called for messages with groups or varData.
+	/// </summary>
+	public int BytesConsumed { get; private set; }
+	
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	internal TradeDataReader(ReadOnlySpan<byte> buffer, int blockLength)
+	{
+		_buffer = buffer;
+		_blockLength = blockLength;
+		BytesConsumed = blockLength;
+	}
+	
+	/// <summary>
+	/// Gets a readonly reference to the TradeData directly in the buffer (zero-copy).
+	/// </summary>
+	public ref readonly TradeData Data => ref Unsafe.As<byte, TradeData>(ref MemoryMarshal.GetReference(_buffer));
 }


### PR DESCRIPTION
## Breaking Change: Zero-copy MessageDataReader API

Replaces the 2-out `TryParse` pattern + `ConsumeVariableLengthSegments` with a zero-copy `MessageDataReader` ref struct.

### Before (v0.9.x)
```csharp
CarData.TryParse(buffer, out var car, out var variableData);
car.SerialNumber;
car.ConsumeVariableLengthSegments(variableData, onFuel, onPerf, ...);
```

### After (v1.0.0)
```csharp
CarData.TryParse(buffer, out var car);
car.Data.SerialNumber;  // zero-copy ref readonly
car.ReadGroups(onFuel, onPerf, ...);
Console.WriteLine(car.BytesConsumed);
```

### Changes
- Generate `{Message}DataReader` ref struct per message — holds `ReadOnlySpan<byte>`, exposes `ref readonly Data` via `Unsafe.As` (zero-copy)
- `TryParse` returns `DataReader` instead of `(out struct, out variableData)`
- Rename `ConsumeVariableLengthSegments` → `ReadGroups` (method on reader)
- `TryParseWithReader` returns reader; caller uses `spanReader.TrySkip(reader.BytesConsumed)` to advance
- `BytesConsumed` property tracks total consumed bytes (block + groups + varData)
- Bump version to **1.0.0**
- Update all examples, docs, and README with new API and migration guide
- All 291 tests passing (172 unit + 119 integration)
