### PR TITLE
fix: B3 UMDF schema compatibility + Binance example fixes (v1.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2026-04-10
+
+### Fixed
+- **B3 UMDF schema compatibility**: Full support for the B3 binary market data SBE schema (v2.2.0). The following issues are now resolved:
+  - **DTD declarations**: Schemas with `<!DOCTYPE>` declarations (like B3 UMDF) no longer fail with SBE004. `DtdProcessing` changed from `Prohibit` to `Ignore`.
+  - **Constant type fields**: Message fields referencing constant types (e.g., `SeqNum1` → `uint32` with value `1`) now resolve to the correct primitive type and value instead of generating empty/invalid code.
+  - **Named optional types in messages**: Fields using named optional types (e.g., `RptSeq`, `FirmOptional`, `QuantityOptional`) now use the underlying primitive type directly, avoiding invalid struct-to-primitive casts.
+  - **Composite optional fields**: Composite types (e.g., `PriceOptional`, `Fixed8`, `Percentage`) used as optional message fields now generate regular fields instead of attempting invalid `== default` comparisons on structs.
+  - **Named type optional resolution**: Regular named types (e.g., `SettlType` → `uint16`) are now correctly resolved when used as optional message fields.
+- **Group-level varData variable shadowing**: When a group and its parent message both have varData fields with the same name (e.g., `Symbol`), the generated code now uses unique variable names to avoid CS0136 errors.
+- **Binance example**: Migrated `ConsoleApp.cs` from deprecated `ConsumeVariableLengthSegments` API to the v1.0.0 `TryParseWithReader`/`ReadGroups` API.
+
 ## [1.0.0] - 2026-04-10
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Or add it directly to your `.csproj`:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="SbeSourceGenerator" Version="1.0.0" />
+  <PackageReference Include="SbeSourceGenerator" Version="1.0.1" />
 </ItemGroup>
 ```
 
@@ -403,4 +403,4 @@ For questions, issues, or feature requests:
 
 ---
 
-**Version**: 1.0.0 (see [Changelog](./CHANGELOG.md))
+**Version**: 1.0.1 (see [Changelog](./CHANGELOG.md))

--- a/examples/SbeBinanceConsole/ConsoleApp.cs
+++ b/examples/SbeBinanceConsole/ConsoleApp.cs
@@ -833,22 +833,24 @@ internal sealed class ConsoleApp : IAsyncDisposable
         snapshot = default;
         eventTime = default;
 
-        if (!reader.TryRead<TradesStreamEventData>(out var trades))
+        if (!TradesStreamEventData.TryParseWithReader(ref reader, TradesStreamEventData.BLOCK_LENGTH, out var tradesReader))
         {
             return false;
         }
 
+        ref readonly var trades = ref tradesReader.Data;
         var symbol = instrument;
         var hasTrade = false;
         TradesStreamEventData.TradesData lastTrade = default;
 
-        trades.ConsumeVariableLengthSegments(ref reader,
-            data =>
+        tradesReader.ReadGroups(
+            (in TradesStreamEventData.TradesData data) =>
             {
                 hasTrade = true;
                 lastTrade = data;
             },
             s => symbol = Encoding.UTF8.GetString(s.VarData[..s.Length]));
+        reader.TrySkip(tradesReader.BytesConsumed);
 
         if (!hasTrade)
         {
@@ -877,15 +879,17 @@ internal sealed class ConsoleApp : IAsyncDisposable
         snapshot = default;
         eventTime = default;
 
-        if (!reader.TryRead<BestBidAskStreamEventData>(out var bestBid))
+        if (!BestBidAskStreamEventData.TryParseWithReader(ref reader, BestBidAskStreamEventData.BLOCK_LENGTH, out var bestBidReader))
         {
             return false;
         }
 
+        ref readonly var bestBid = ref bestBidReader.Data;
         var symbol = instrument;
 
-        bestBid.ConsumeVariableLengthSegments(ref reader,
+        bestBidReader.ReadGroups(
             s => symbol = Encoding.UTF8.GetString(s.VarData[..s.Length]));
+        reader.TrySkip(bestBidReader.BytesConsumed);
 
         var qtyMultiplier = Pow10(bestBid.QtyExponent.Value);
         var priceMultiplier = Pow10(bestBid.PriceExponent.Value);

--- a/src/SbeCodeGenerator/Generators/MessagesCodeGenerator.cs
+++ b/src/SbeCodeGenerator/Generators/MessagesCodeGenerator.cs
@@ -224,29 +224,60 @@ namespace SbeSourceGenerator.Generators
                 {
                     var underlyingType = GetUnderlyingType(field.Type, context);
                     var effectivePrimitiveType = underlyingType ?? resolvedType;
-                    if (!TypesCatalog.HasNullValue(effectivePrimitiveType)
-                        && string.IsNullOrEmpty(field.NullValue)
-                        && sourceContext.CancellationToken != default)
-                    {
-                        sourceContext.ReportDiagnostic(Diagnostic.Create(
-                            SbeDiagnostics.UnknownPrimitiveTypeFallback,
-                            Location.None,
-                            effectivePrimitiveType, "null sentinel", field.Name));
-                    }
 
-                    result.Add(new OptionalMessageFieldDefinition(
-                        generatedFieldName,
-                        field.Id,
-                        resolvedType,
-                        effectivePrimitiveType,
-                        field.Description,
-                        ParseOffset(field.Offset, field.Name, sourceContext),
-                        TypeResolverHelper.GetTypeLength(field.Type, context),
-                        field.SinceVersion,
-                        field.Deprecated,
-                        field.NullValue == "" ? null : field.NullValue,
-                        context.EndianConversion
-                    ));
+                    // When the effective type is not a known primitive (composites, char arrays),
+                    // we can't generate optional null-check code. Fall back to a regular field.
+                    if (!TypesCatalog.HasNullValue(effectivePrimitiveType) && string.IsNullOrEmpty(field.NullValue))
+                    {
+                        var fieldUnderlyingType = GetUnderlyingType(field.Type, context);
+                        result.Add(new MessageFieldDefinition(
+                            generatedFieldName,
+                            field.Id,
+                            resolvedType,
+                            field.Description,
+                            ParseOffset(field.Offset, field.Name, sourceContext),
+                            TypeResolverHelper.GetTypeLength(field.Type, context),
+                            field.SinceVersion,
+                            field.Deprecated,
+                            context.EndianConversion,
+                            fieldUnderlyingType
+                        ));
+                    }
+                    else
+                    {
+                        // When the field references a named optional type (e.g., "RptSeq"),
+                        // use the underlying primitive type directly instead of the wrapper struct.
+                        // Also propagate the null value from the type definition.
+                        var fieldType = resolvedType;
+                        var fieldNullValue = field.NullValue == "" ? null : field.NullValue;
+                        if (context.OptionalTypes.TryGetValue(field.Type, out var optionalTypeInfo))
+                        {
+                            fieldType = effectivePrimitiveType;
+                            if (fieldNullValue == null && !string.IsNullOrEmpty(optionalTypeInfo.NullValue))
+                            {
+                                fieldNullValue = optionalTypeInfo.NullValue;
+                            }
+                        }
+                        else if (context.TypePrimitiveMapping.ContainsKey(field.Type))
+                        {
+                            // Regular named type used as optional field - use primitive type directly
+                            fieldType = effectivePrimitiveType;
+                        }
+
+                        result.Add(new OptionalMessageFieldDefinition(
+                            generatedFieldName,
+                            field.Id,
+                            fieldType,
+                            effectivePrimitiveType,
+                            field.Description,
+                            ParseOffset(field.Offset, field.Name, sourceContext),
+                            TypeResolverHelper.GetTypeLength(field.Type, context),
+                            field.SinceVersion,
+                            field.Deprecated,
+                            fieldNullValue,
+                            context.EndianConversion
+                        ));
+                    }
                 }
                 else
                 {
@@ -274,12 +305,24 @@ namespace SbeSourceGenerator.Generators
             var result = new List<IFileContentGenerator>(constants.Count);
             foreach (var constant in constants)
             {
+                var type = constant.Type;
+                var resolvedType = TypeResolverHelper.ResolveTypeName(TypeTranslator.Translate(type).PrimitiveType, context);
+                var valueRef = TypeResolverHelper.NormalizeValueRef(constant.ValueRef, context);
+
+                // When a constant field references a constant type (e.g., SeqNum1),
+                // resolve to the primitive type and use the type's stored value.
+                if (string.IsNullOrWhiteSpace(valueRef) && context.ConstantTypeInfo.TryGetValue(type, out var info))
+                {
+                    resolvedType = info.PrimitiveType;
+                    valueRef = info.Value;
+                }
+
                 result.Add(new ConstantMessageFieldDefinition(
                     TypeTranslator.NormalizeName(constant.Name),
                     constant.Id,
-                    TypeResolverHelper.ResolveTypeName(TypeTranslator.Translate(constant.Type).PrimitiveType, context),
+                    resolvedType,
                     constant.Description != "" ? constant.Description : constant.Type,
-                    TypeResolverHelper.NormalizeValueRef(constant.ValueRef, context)
+                    valueRef
                 ));
             }
             return result;
@@ -375,8 +418,12 @@ namespace SbeSourceGenerator.Generators
                 return underlyingType;
 
             // Check if it's an optional type (e.g., Int64NULL)
-            if (context.OptionalTypes.TryGetValue(type, out underlyingType))
-                return underlyingType;
+            if (context.OptionalTypes.TryGetValue(type, out var optionalInfo))
+                return optionalInfo.PrimitiveType;
+
+            // Check if it's a regular named type wrapping a primitive (e.g., SettlType -> ushort)
+            if (context.TypePrimitiveMapping.TryGetValue(type, out var primitiveType))
+                return primitiveType;
 
             return null;
         }

--- a/src/SbeCodeGenerator/Generators/Types/MessageDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Types/MessageDefinition.cs
@@ -263,11 +263,13 @@ namespace SbeSourceGenerator
             sb.Append("in ").Append(dataVarName).AppendLine(");");
 
             // Read group-level variable data after each entry
+            // Prefix with group name to avoid variable shadowing with message-level varData
             foreach (var groupData in group.TypedDatas)
             {
-                sb.AppendTabs(tabs).Append("var datas").Append(groupData.Name).Append(" = ").Append(groupData.Type).AppendLine(".Create(reader.Remaining);");
-                sb.AppendTabs(tabs).Append("callback").Append(group.Name).Append(groupData.Name).Append("(datas").Append(groupData.Name).AppendLine(");");
-                sb.AppendTabs(tabs).Append("reader.TrySkip(datas").Append(groupData.Name).AppendLine(".TotalLength);");
+                var varName = $"datas{group.Name}{groupData.Name}";
+                sb.AppendTabs(tabs).Append("var ").Append(varName).Append(" = ").Append(groupData.Type).AppendLine(".Create(reader.Remaining);");
+                sb.AppendTabs(tabs).Append("callback").Append(group.Name).Append(groupData.Name).Append("(").Append(varName).AppendLine(");");
+                sb.AppendTabs(tabs).Append("reader.TrySkip(").Append(varName).AppendLine(".TotalLength);");
             }
             // Read nested groups recursively
             var ancestorsForChildren = new List<string>(ancestors);

--- a/src/SbeCodeGenerator/Generators/TypesCodeGenerator.cs
+++ b/src/SbeCodeGenerator/Generators/TypesCodeGenerator.cs
@@ -156,10 +156,13 @@ namespace SbeSourceGenerator.Generators
                     )
                 };
                 if (generator is ConstantTypeDefinition)
+                {
                     context.CustomConstantTypes[typeDto.Name] = 0;
+                    context.ConstantTypeInfo[typeDto.Name] = (TypeResolverHelper.ResolveTypeName(nativeType, context), typeDto.InnerText);
+                }
                 if (generator is OptionalTypeDefinition)
                 {
-                    context.OptionalTypes[typeDto.Name] = nativeType;
+                    context.OptionalTypes[typeDto.Name] = (nativeType, typeDto.NullValue);
                     var resolvedType = TypeResolverHelper.ResolveTypeName(nativeType, context);
                     if (string.IsNullOrEmpty(typeDto.NullValue) && !TypesCatalog.HasNullValue(resolvedType)
                         && sourceContext.CancellationToken != default)
@@ -169,6 +172,10 @@ namespace SbeSourceGenerator.Generators
                             Location.None,
                             resolvedType, "null sentinel", typeDto.Name));
                     }
+                }
+                if (generator is TypeDefinition)
+                {
+                    context.TypePrimitiveMapping[typeDto.Name] = TypeResolverHelper.ResolveTypeName(nativeType, context);
                 }
                 if (generator is IBlittable blittableType)
                     context.CustomTypeLengths[typeDto.Name] = blittableType.Length;

--- a/src/SbeCodeGenerator/SbeSourceGenerator.csproj
+++ b/src/SbeCodeGenerator/SbeSourceGenerator.csproj
@@ -11,7 +11,7 @@
 		<IncludeBuildOutput>false</IncludeBuildOutput>
 		<PackageId>SbeSourceGenerator</PackageId>
 		<Title>SBE Source Generator</Title>
-		<Version>1.0.0</Version>
+		<Version>1.0.1</Version>
 		<Authors>Pedro Sakuma</Authors>
 		<Company>Pedro Sakuma</Company>
 		<Product>SBE Source Generator</Product>

--- a/src/SbeCodeGenerator/Schema/SchemaReader.cs
+++ b/src/SbeCodeGenerator/Schema/SchemaReader.cs
@@ -32,7 +32,7 @@ namespace SbeSourceGenerator.Schema
 
             var settings = new XmlReaderSettings
             {
-                DtdProcessing = DtdProcessing.Prohibit,
+                DtdProcessing = DtdProcessing.Ignore,
                 XmlResolver = null,
                 IgnoreComments = true,
                 IgnoreWhitespace = true

--- a/src/SbeCodeGenerator/SchemaContext.cs
+++ b/src/SbeCodeGenerator/SchemaContext.cs
@@ -23,6 +23,13 @@ namespace SbeSourceGenerator
         public Dictionary<string, byte> CustomConstantTypes { get; } = new Dictionary<string, byte>(8);
 
         /// <summary>
+        /// Stores the resolved primitive type and value for constant types.
+        /// Maps type name → (PrimitiveType, Value).
+        /// Used when a message constant field references a constant type (e.g., SeqNum1 → ("uint", "1")).
+        /// </summary>
+        public Dictionary<string, (string PrimitiveType, string Value)> ConstantTypeInfo { get; } = new Dictionary<string, (string, string)>(8);
+
+        /// <summary>
         /// Maps original schema identifiers to the generated identifiers emitted in C# code.
         /// Helps keep references (valueRef, composites, enums) consistent after normalization.
         /// </summary>
@@ -35,10 +42,18 @@ namespace SbeSourceGenerator
         public HashSet<string> GeneratedRuntimeNamespaces { get; }
 
         /// <summary>
-        /// Tracks which types are optional types (have presence="optional").
-        /// Maps type name to its underlying primitive type (e.g., "Int64NULL" -> "long").
+        /// Maps non-optional, non-constant named types to their underlying C# primitive type.
+        /// e.g., "SettlType" -> "ushort". Used when such types are referenced in optional message fields.
+        /// Composites and char array types are NOT included (they don't have a single underlying primitive).
         /// </summary>
-        public Dictionary<string, string> OptionalTypes { get; } = new Dictionary<string, string>(8);
+        public Dictionary<string, string> TypePrimitiveMapping { get; } = new Dictionary<string, string>(16);
+
+        /// <summary>
+        /// Tracks which types are optional types (have presence="optional").
+        /// Maps type name to (underlying primitive type, null value).
+        /// e.g., "Int64NULL" -> ("long", ""), "RptSeq" -> ("uint", "0").
+        /// </summary>
+        public Dictionary<string, (string PrimitiveType, string NullValue)> OptionalTypes { get; } = new Dictionary<string, (string, string)>(8);
 
         /// <summary>
         /// Tracks composite types and their field types.

--- a/tests/SbeCodeGenerator.Tests/DiagnosticsTests.cs
+++ b/tests/SbeCodeGenerator.Tests/DiagnosticsTests.cs
@@ -200,5 +200,26 @@ namespace SbeCodeGenerator.Tests
             TypeResolverHelper.RegisterGeneratedTypeName(context, "MyType");
             Assert.True(context.GeneratedTypeNames.ContainsKey("MyType"));
         }
+
+        [Fact]
+        public void SchemaReader_Parse_WithDoctypeDeclaration_DoesNotThrow()
+        {
+            // B3 UMDF schema includes <!DOCTYPE xml> which must be tolerated
+            var schema = SchemaReader.Parse(@"<?xml version=""1.0"" encoding=""UTF-8""?>
+                <!DOCTYPE xml>
+                <sbe:messageSchema xmlns:sbe='http://fixprotocol.io/2016/sbe'
+                    package='test.schema' id='1' version='1' byteOrder='littleEndian'>
+                    <types>
+                        <type name='TestType' primitiveType='uint32'/>
+                    </types>
+                    <sbe:message name='TestMsg' id='1' description='Test'>
+                        <field name='field1' id='1' type='uint32'/>
+                    </sbe:message>
+                </sbe:messageSchema>");
+
+            Assert.NotNull(schema);
+            Assert.Equal("test.schema", schema.Package);
+            Assert.Single(schema.Messages);
+        }
     }
 }

--- a/tests/SbeCodeGenerator.Tests/MessagesCodeGeneratorTests.cs
+++ b/tests/SbeCodeGenerator.Tests/MessagesCodeGeneratorTests.cs
@@ -636,5 +636,96 @@ namespace SbeCodeGenerator.Tests
             Assert.Contains("return MessageHeader.MESSAGE_SIZE;", msgResult.content);
         }
 
+        [Fact]
+        public void Generate_WithConstantTypeField_ResolvesToPrimitiveTypeAndValue()
+        {
+            // Arrange - SeqNum1 is a constant type (uint32, value=1), used as a constant field in a message
+            var generator = new MessagesCodeGenerator();
+            var context = new SchemaContext("test-schema");
+            var schema = SchemaReader.Parse(@"
+                <sbe:messageSchema xmlns:sbe='http://fixprotocol.io/2016/sbe'>
+                    <types>
+                        <type name='SeqNum1' primitiveType='uint32' presence='constant'>1</type>
+                    </types>
+                    <sbe:message name='TestMessage' id='1' description='Test'>
+                        <field name='seqNo' id='1' type='SeqNum1' presence='constant'/>
+                        <field name='field1' id='2' type='uint32'/>
+                    </sbe:message>
+                </sbe:messageSchema>");
+
+            var typesGenerator = new TypesCodeGenerator();
+            _ = typesGenerator.Generate("TestNs", schema, context, default(SourceProductionContext)).ToList();
+
+            // Act
+            var results = generator.Generate("TestNs", schema, context, default(SourceProductionContext));
+            var msgResult = results.First(r => r.name.Contains("TestMessage"));
+
+            // Assert - should use the primitive type (uint) and the constant value (1), not the wrapper type
+            Assert.Contains("public const uint SEQ_NO = 1;", msgResult.content);
+        }
+
+        [Fact]
+        public void Generate_WithNamedOptionalTypeField_UsesPrimitiveType()
+        {
+            // Arrange - RptSeq is a named optional type (uint32, nullValue=0)
+            var generator = new MessagesCodeGenerator();
+            var context = new SchemaContext("test-schema");
+            var schema = SchemaReader.Parse(@"
+                <sbe:messageSchema xmlns:sbe='http://fixprotocol.io/2016/sbe'>
+                    <types>
+                        <type name='RptSeq' primitiveType='uint32' presence='optional' nullValue='0'/>
+                    </types>
+                    <sbe:message name='TestMessage' id='1' description='Test'>
+                        <field name='rptSeq' id='1' type='RptSeq'/>
+                        <field name='field1' id='2' type='uint32'/>
+                    </sbe:message>
+                </sbe:messageSchema>");
+
+            var typesGenerator = new TypesCodeGenerator();
+            _ = typesGenerator.Generate("TestNs", schema, context, default(SourceProductionContext)).ToList();
+
+            // Act
+            var results = generator.Generate("TestNs", schema, context, default(SourceProductionContext));
+            var msgResult = results.First(r => r.name.Contains("TestMessage"));
+
+            // Assert - should use uint (not RptSeq struct) and nullValue=0
+            Assert.Contains("private uint rptSeq;", msgResult.content);
+            Assert.Contains("uint?", msgResult.content);
+            Assert.Contains("== 0", msgResult.content);
+        }
+
+        [Fact]
+        public void Generate_WithCompositeOptionalField_CreatesRegularField()
+        {
+            // Arrange - PriceOptional is a composite type used as optional field
+            var generator = new MessagesCodeGenerator();
+            var context = new SchemaContext("test-schema");
+            var schema = SchemaReader.Parse(@"
+                <sbe:messageSchema xmlns:sbe='http://fixprotocol.io/2016/sbe'>
+                    <types>
+                        <composite name='PriceOptional' description='Optional price'>
+                            <type name='mantissa' primitiveType='int64' presence='optional'/>
+                            <type name='exponent' primitiveType='int8' presence='constant'>-4</type>
+                        </composite>
+                    </types>
+                    <sbe:message name='TestMessage' id='1' description='Test'>
+                        <field name='price' id='1' type='PriceOptional' presence='optional'/>
+                        <field name='field1' id='2' type='uint32'/>
+                    </sbe:message>
+                </sbe:messageSchema>");
+
+            var typesGenerator = new TypesCodeGenerator();
+            _ = typesGenerator.Generate("TestNs", schema, context, default(SourceProductionContext)).ToList();
+
+            // Act
+            var results = generator.Generate("TestNs", schema, context, default(SourceProductionContext));
+            var msgResult = results.First(r => r.name.Contains("TestMessage"));
+
+            // Assert - should be a regular field (not optional), composites handle their own null semantics
+            Assert.Contains("public PriceOptional Price;", msgResult.content);
+            Assert.DoesNotContain("PriceOptional?", msgResult.content); // No nullable
+            Assert.DoesNotContain("== default", msgResult.content); // No default comparison
+        }
+
     }
 }


### PR DESCRIPTION
## Summary

Fixes multiple code generation issues preventing the **B3 UMDF market data SBE schema (v2.2.0)** from compiling, plus fixes for the Binance example project.

## Fixes

### B3 UMDF Schema Compatibility
- **Constant type fields**: `SeqNum1` → resolves to `uint = 1` correctly
- **Named optional types**: `RptSeq`, `FirmOptional`, etc. use underlying primitive type directly
- **Composite optional fields**: `PriceOptional`, `Fixed8`, `Percentage` generate regular fields
- **Named type optional resolution**: `SettlType` → `ushort` resolved correctly as optional

### Generator Bug Fix
- **Group-level varData variable shadowing (CS0136)**: When a group and message share a varData field name (e.g., `Symbol`), variables are now uniquely named

### Binance Example
- Migrated `ConsoleApp.cs` from deprecated `ConsumeVariableLengthSegments` to v1.0.0 `TryParseWithReader`/`ReadGroups` API

## Testing
- ✅ 176 unit tests passing
- ✅ 119 integration tests passing  
- ✅ Binance example builds with 0 errors
- ✅ B3 UMDF schema v2.2.0 compiles cleanly (validated with temporary test project)