### PR TITLE
fix: eliminate CS8656 defensive copies in nullable composite properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2026-04-10
+
+### Fixed
+- **CS8656 defensive copy elimination**: Added `readonly` modifier to nullable composite property getters (e.g., `Mantissa`, `Time`, `Year`, `Month`, `Day`, `Week`). Eliminates 11 CS8656 warnings across 8 composites (`RatioQty`, `Percentage`, `PriceOptional`, `UTCTimestampNanos`, `PriceOffset8Optional`, `UTCTimestampSeconds`, `Fixed8`, `MaturityMonthYear`) where the `readonly ToString()` called non-readonly property getters, causing silent defensive copies.
+
 ## [1.0.1] - 2026-04-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Or add it directly to your `.csproj`:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="SbeSourceGenerator" Version="1.0.1" />
+  <PackageReference Include="SbeSourceGenerator" Version="1.0.2" />
 </ItemGroup>
 ```
 
@@ -403,4 +403,4 @@ For questions, issues, or feature requests:
 
 ---
 
-**Version**: 1.0.1 (see [Changelog](./CHANGELOG.md))
+**Version**: 1.0.2 (see [Changelog](./CHANGELOG.md))

--- a/src/SbeCodeGenerator/Generators/Fields/NullableValueFieldDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Fields/NullableValueFieldDefinition.cs
@@ -15,7 +15,7 @@ namespace SbeSourceGenerator
             sb.AppendSummary(Description, tabs, nameof(NullableValueFieldDefinition));
             sb.AppendLine("#pragma warning disable CS0649", tabs);
             sb.AppendTabs(tabs).Append("private ").Append(PrimitiveType).Append(" ").Append(fieldName).AppendLine(";");
-            sb.AppendTabs(tabs).Append("public ").Append(PrimitiveType).Append("? ").Append(Name);
+            sb.AppendTabs(tabs).Append("public readonly ").Append(PrimitiveType).Append("? ").Append(Name);
             AppendNullCheck(sb, PrimitiveType, getExpr, nullValue);
             sb.AppendLine("#pragma warning restore CS0649", tabs);
         }

--- a/src/SbeCodeGenerator/SbeSourceGenerator.csproj
+++ b/src/SbeCodeGenerator/SbeSourceGenerator.csproj
@@ -11,7 +11,7 @@
 		<IncludeBuildOutput>false</IncludeBuildOutput>
 		<PackageId>SbeSourceGenerator</PackageId>
 		<Title>SBE Source Generator</Title>
-		<Version>1.0.1</Version>
+		<Version>1.0.2</Version>
 		<Authors>Pedro Sakuma</Authors>
 		<Company>Pedro Sakuma</Company>
 		<Product>SBE Source Generator</Product>


### PR DESCRIPTION
## Summary

Add `readonly` modifier to nullable composite property getters generated by `NullableValueFieldDefinition`.

## Problem

`ToString()` is generated as `readonly`, but nullable property getters (e.g., `Mantissa`, `Time`, `Year`) were not `readonly`. The compiler emits CS8656 and silently creates defensive struct copies — no functional bug, but unnecessary overhead.

**11 warnings across 8 composites**: RatioQty, Percentage, PriceOptional, UTCTimestampNanos, PriceOffset8Optional, UTCTimestampSeconds, Fixed8, MaturityMonthYear.

## Fix

```diff
- public long? Mantissa => mantissa == ... ? null : mantissa;
+ public readonly long? Mantissa => mantissa == ... ? null : mantissa;
```

Bumps version to **1.0.2**.