### PR TITLE
feat: consumer improvements v1.1.0 (#131-#137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **`ToDecimal()` on decimal composites** (#131): Composites with the SBE decimal pattern (mantissa + constant exponent) now generate a `ToDecimal()` method. Optional mantissa returns `decimal?`, non-optional returns `decimal`. Uses pre-computed decimal literal (e.g., `1e-4m`) for zero-overhead conversion.
+- **`ToDateTime()` / `ToDateTimeOffset()` on timestamp composites** (#132): Composites with the SBE timestamp pattern (time + constant unit) now generate conversion methods. Supports nanosecond, microsecond, millisecond, and second time units. Optional time returns nullable types.
+- **`ToDateOnly()` on LocalMktDate and MonthYear** (#133): Types with `semanticType="LocalMktDate"` generate `ToDateOnly()` (days since epoch). Composites with `semanticType="MonthYear"` generate `ToDateOnly()` using year/month/day fields.
+- **`AsSpan()` and `Equals(ReadOnlySpan<byte>)` on InlineArray char types** (#134): Zero-allocation content access and comparison. `AsSpan()` returns trimmed content excluding null-termination. `Equals()` enables comparison with UTF-8 string literals (e.g., `symbol.Equals("PETR4"u8)`).
+- **Named null sentinel constants** (#136): Optional fields now expose a named `{FieldName}NullValue` constant (e.g., `MantissaNullValue`, `TimeNullValue`) instead of inline magic numbers.
+
+### Changed
+- **Field visibility standardization** (#137): All struct fields now use `private` backing fields with `public` property accessors (`readonly get` + `set`). Composite/InlineArray fields use `ref`-returning properties with `[UnscopedRef]`.
+- **`readonly` methods on generated structs** (#135): `TryEncode`, `TryEncodeWithWriter`, `Encode`, `AsSpan`, `Equals`, and `ToString` are now `readonly` instance methods to prevent defensive copies. `ConstantTypeDefinition` emits `readonly struct`.
+
 ## [1.0.2] - 2026-04-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.1.0] - 2026-04-15
 
 ### Added
 - **`ToDecimal()` on decimal composites** (#131): Composites with the SBE decimal pattern (mantissa + constant exponent) now generate a `ToDecimal()` method. Optional mantissa returns `decimal?`, non-optional returns `decimal`. Uses pre-computed decimal literal (e.g., `1e-4m`) for zero-overhead conversion.

--- a/src/SbeCodeGenerator/EndianFieldHelper.cs
+++ b/src/SbeCodeGenerator/EndianFieldHelper.cs
@@ -22,42 +22,56 @@ namespace SbeSourceGenerator
         }
 
         /// <summary>
-        /// Appends a field declaration with endian-aware property if needed.
-        /// For single-byte or EndianConversion.None: emits a public field.
-        /// For multi-byte with conversion: emits private field + public property.
+        /// Appends a field declaration with consistent property pattern.
+        /// Always emits private backing field + public property with readonly get and set.
         /// </summary>
         public static void AppendField(StringBuilder sb, int tabs, string type, string name,
             EndianConversion conversion)
         {
+            string fieldName = name.FirstCharToLower();
+            sb.AppendTabs(tabs).Append("private ").Append(type).Append(" ").Append(fieldName).AppendLine(";");
+
             if (!NeedsConversion(type, conversion))
             {
-                sb.AppendTabs(tabs).Append("public ").Append(type).Append(" ").Append(name).AppendLine(";");
+                sb.AppendTabs(tabs).Append("public ").Append(type).Append(" ").Append(name)
+                    .Append(" { readonly get => ").Append(fieldName)
+                    .Append("; set => ").Append(fieldName).Append(" = value; }")
+                    .AppendLine();
                 return;
             }
 
-            string fieldName = name.FirstCharToLower();
-            sb.AppendTabs(tabs).Append("private ").Append(type).Append(" ").Append(fieldName).AppendLine(";");
             AppendPropertyWithConversion(sb, tabs, type, name, fieldName, conversion);
         }
 
         /// <summary>
-        /// Appends a message field declaration with [FieldOffset] and endian-aware property if needed.
-        /// declaredType is the C# declared type (e.g., "MyEnum" or "int").
-        /// primitiveType is the underlying numeric type used for endian conversion (e.g., "ushort" for a ushort-backed enum).
+        /// Appends a message field declaration with [FieldOffset] and consistent property pattern.
+        /// For struct types (composites, InlineArrays), emits ref-returning property to allow sub-field mutation.
+        /// For primitive/enum types, emits private backing field + public property with readonly get and set.
         /// </summary>
         public static void AppendMessageField(StringBuilder sb, int tabs, string declaredType, string primitiveType, string name,
-            int? offset, EndianConversion conversion)
+            int? offset, EndianConversion conversion, bool isStructType = false)
         {
             sb.AppendTabs(tabs).Append("[FieldOffset(").Append(offset).AppendLine(")]");
 
-            if (!NeedsConversion(primitiveType, conversion))
+            string fieldName = name.FirstCharToLower();
+            sb.AppendTabs(tabs).Append("private ").Append(declaredType).Append(" ").Append(fieldName).AppendLine(";");
+
+            if (isStructType)
             {
-                sb.AppendTabs(tabs).Append("public ").Append(declaredType).Append(" ").Append(name).AppendLine(";");
+                sb.AppendTabs(tabs).AppendLine("[System.Diagnostics.CodeAnalysis.UnscopedRef]");
+                sb.AppendTabs(tabs).Append("public ref ").Append(declaredType).Append(" ").Append(name)
+                    .Append(" => ref ").Append(fieldName).AppendLine(";");
                 return;
             }
 
-            string fieldName = name.FirstCharToLower();
-            sb.AppendTabs(tabs).Append("private ").Append(declaredType).Append(" ").Append(fieldName).AppendLine(";");
+            if (!NeedsConversion(primitiveType, conversion))
+            {
+                sb.AppendTabs(tabs).Append("public ").Append(declaredType).Append(" ").Append(name)
+                    .Append(" { readonly get => ").Append(fieldName)
+                    .Append("; set => ").Append(fieldName).Append(" = value; }")
+                    .AppendLine();
+                return;
+            }
 
             bool needsCast = declaredType != primitiveType;
             string getExpr = needsCast

--- a/src/SbeCodeGenerator/Generators/Fields/CompositeRefFieldDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Fields/CompositeRefFieldDefinition.cs
@@ -10,8 +10,12 @@ namespace SbeSourceGenerator
     {
         public void AppendFileContent(StringBuilder sb, int tabs = 0)
         {
+            string fieldName = Name.FirstCharToLower();
             sb.AppendSummary(Description, tabs, nameof(CompositeRefFieldDefinition));
-            sb.AppendTabs(tabs).Append("public ").Append(TypeName).Append(" ").Append(Name).AppendLine(";");
+            sb.AppendTabs(tabs).Append("private ").Append(TypeName).Append(" ").Append(fieldName).AppendLine(";");
+            sb.AppendTabs(tabs).AppendLine("[System.Diagnostics.CodeAnalysis.UnscopedRef]");
+            sb.AppendTabs(tabs).Append("public ref ").Append(TypeName).Append(" ").Append(Name)
+                .Append(" => ref ").Append(fieldName).AppendLine(";");
         }
     }
 }

--- a/src/SbeCodeGenerator/Generators/Fields/MessageFieldDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Fields/MessageFieldDefinition.cs
@@ -14,10 +14,12 @@ namespace SbeSourceGenerator
         public string SinceVersion { get; }
         public string Deprecated { get; }
         public EndianConversion EndianConversion { get; }
+        public bool IsStructType { get; }
 
         public MessageFieldDefinition(string Name, string Id, string Type, string Description,
             int? Offset, int Length, string SinceVersion = "", string Deprecated = "",
-            EndianConversion EndianConversion = EndianConversion.None, string? PrimitiveType = null)
+            EndianConversion EndianConversion = EndianConversion.None, string? PrimitiveType = null,
+            bool IsStructType = false)
         {
             this.Name = Name;
             this.Id = Id;
@@ -29,6 +31,7 @@ namespace SbeSourceGenerator
             this.SinceVersion = SinceVersion;
             this.Deprecated = Deprecated;
             this.EndianConversion = EndianConversion;
+            this.IsStructType = IsStructType;
         }
         public void AppendFileContent(StringBuilder sb, int tabs = 0)
         {
@@ -41,7 +44,7 @@ namespace SbeSourceGenerator
                 sb.AppendTabs(tabs).Append("[Obsolete(\"").Append(deprecatedSince).AppendLine("\")]");
             }
             string effectiveType = PrimitiveType ?? Type;
-            EndianFieldHelper.AppendMessageField(sb, tabs, Type, effectiveType, Name, Offset, EndianConversion);
+            EndianFieldHelper.AppendMessageField(sb, tabs, Type, effectiveType, Name, Offset, EndianConversion, IsStructType);
         }
 
         private void AppendSummaryWithVersion(StringBuilder sb, string description, string sinceVersion, int tabs)

--- a/src/SbeCodeGenerator/Generators/Fields/NullableValueFieldDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Fields/NullableValueFieldDefinition.cs
@@ -11,21 +11,30 @@ namespace SbeSourceGenerator
             string nullValue = NullValue ?? TypesCatalog.GetNullValue(PrimitiveType);
             string fieldName = Name.FirstCharToLower();
             string getExpr = EndianFieldHelper.GetterExpression(PrimitiveType, fieldName, EndianConversion);
+            string constantName = Name + "NullValue";
 
             sb.AppendSummary(Description, tabs, nameof(NullableValueFieldDefinition));
             sb.AppendLine("#pragma warning disable CS0649", tabs);
+            AppendNullConstant(sb, tabs, PrimitiveType, constantName, nullValue);
             sb.AppendTabs(tabs).Append("private ").Append(PrimitiveType).Append(" ").Append(fieldName).AppendLine(";");
             sb.AppendTabs(tabs).Append("public readonly ").Append(PrimitiveType).Append("? ").Append(Name);
-            AppendNullCheck(sb, PrimitiveType, getExpr, nullValue);
+            AppendNullCheck(sb, PrimitiveType, getExpr, nullValue, constantName);
             sb.AppendLine("#pragma warning restore CS0649", tabs);
         }
 
-        internal static void AppendNullCheck(StringBuilder sb, string primitiveType, string valueExpr, string nullValue)
+        internal static void AppendNullConstant(StringBuilder sb, int tabs, string primitiveType, string constantName, string nullValue)
+        {
+            if (TypesCatalog.IsFloatingPoint(primitiveType))
+                return; // Floating-point uses IsNaN, no sentinel constant needed
+            sb.AppendTabs(tabs).Append("public const ").Append(primitiveType).Append(" ").Append(constantName).Append(" = ").Append(nullValue).AppendLine(";");
+        }
+
+        internal static void AppendNullCheck(StringBuilder sb, string primitiveType, string valueExpr, string nullValue, string? constantName = null)
         {
             if (TypesCatalog.IsFloatingPoint(primitiveType))
                 sb.Append(" => ").Append(primitiveType).Append(".IsNaN(").Append(valueExpr).Append(") ? null : ").Append(valueExpr).AppendLine(";");
             else
-                sb.Append(" => ").Append(valueExpr).Append(" == ").Append(nullValue).Append(" ? null : ").Append(valueExpr).AppendLine(";");
+                sb.Append(" => ").Append(valueExpr).Append(" == ").Append(constantName ?? nullValue).Append(" ? null : ").Append(valueExpr).AppendLine(";");
         }
     }
 }

--- a/src/SbeCodeGenerator/Generators/Fields/OptionalMessageFieldDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Fields/OptionalMessageFieldDefinition.cs
@@ -43,11 +43,14 @@ namespace SbeSourceGenerator
                     : $"This field is deprecated since version {SinceVersion}";
                 sb.AppendTabs(tabs).Append("[Obsolete(\"").Append(deprecatedSince).AppendLine("\")]");
             }
-            sb.AppendTabs(tabs).Append("[FieldOffset(").Append(Offset).AppendLine(")]");
             if (PrimitiveType != null)
             {
                 var nullValue = NullValue ?? TypesCatalog.GetNullValue(PrimitiveType);
                 string fieldName = Name.FirstCharToLower();
+                string constantName = Name + "NullValue";
+
+                NullableValueFieldDefinition.AppendNullConstant(sb, tabs, PrimitiveType, constantName, nullValue);
+                sb.AppendTabs(tabs).Append("[FieldOffset(").Append(Offset).AppendLine(")]");
                 sb.AppendTabs(tabs).Append("private ").Append(Type).Append(" ").Append(fieldName).AppendLine(";");
 
                 if (isDeprecated)
@@ -64,7 +67,7 @@ namespace SbeSourceGenerator
                 }
                 else
                 {
-                    sb.AppendTabs(tabs).Append("public readonly ").Append(Type).Append("? ").Append(Name).Append(" => (").Append(PrimitiveType).Append(")").Append(getExpr).Append(" == ").Append(nullValue).Append(" ? null : ").Append(getExpr).AppendLine(";");
+                    sb.AppendTabs(tabs).Append("public readonly ").Append(Type).Append("? ").Append(Name).Append(" => (").Append(PrimitiveType).Append(")").Append(getExpr).Append(" == ").Append(constantName).Append(" ? null : ").Append(getExpr).AppendLine(";");
                 }
                 sb.AppendTabs(tabs).Append("public void Set").Append(Name).Append("(").Append(Type).Append("? value) => ").Append(fieldName).Append(" = value.HasValue ? (").Append(Type).Append(")").Append(EndianFieldHelper.SetterExpression(PrimitiveType, "value.Value", EndianConversion)).Append(" : ").Append(setNullExpr).AppendLine(";");
 
@@ -73,6 +76,7 @@ namespace SbeSourceGenerator
             }
             else
             {
+                sb.AppendTabs(tabs).Append("[FieldOffset(").Append(Offset).AppendLine(")]");
                 sb.AppendTabs(tabs).Append("public ").Append(Type).Append(" ").Append(Name).AppendLine(";");
             }
         }

--- a/src/SbeCodeGenerator/Generators/MessagesCodeGenerator.cs
+++ b/src/SbeCodeGenerator/Generators/MessagesCodeGenerator.cs
@@ -240,7 +240,8 @@ namespace SbeSourceGenerator.Generators
                             field.SinceVersion,
                             field.Deprecated,
                             context.EndianConversion,
-                            fieldUnderlyingType
+                            fieldUnderlyingType,
+                            context.StructTypeNames.Contains(field.Type)
                         ));
                     }
                     else
@@ -293,7 +294,8 @@ namespace SbeSourceGenerator.Generators
                         field.SinceVersion,
                         field.Deprecated,
                         context.EndianConversion,
-                        underlyingType
+                        underlyingType,
+                        context.StructTypeNames.Contains(field.Type)
                     ));
                 }
             }
@@ -356,7 +358,8 @@ namespace SbeSourceGenerator.Generators
                         field.SinceVersion,
                         field.Deprecated,
                         context.EndianConversion,
-                        underlyingFieldType
+                        underlyingFieldType,
+                        context.StructTypeNames.Contains(field.Type)
                     ));
                 }
 

--- a/src/SbeCodeGenerator/Generators/Types/ConstantTypeDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Types/ConstantTypeDefinition.cs
@@ -17,7 +17,7 @@ namespace SbeSourceGenerator
 
             sb.Append("namespace ").Append(Namespace).AppendLine(";");
             sb.AppendSummary(Description, tabs, nameof(ConstantTypeDefinition));
-            sb.Append("public struct ").AppendLine(Name);
+            sb.Append("public readonly struct ").AppendLine(Name);
             sb.AppendLine("{", tabs++);
             sb.AppendTabs(tabs).Append("public const ").Append(primitiveType).Append(" Value = ").Append(value).AppendLine(";");
             sb.AppendLine("}", --tabs);

--- a/src/SbeCodeGenerator/Generators/Types/DateHelperDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Types/DateHelperDefinition.cs
@@ -1,0 +1,83 @@
+﻿using System.Text;
+
+namespace SbeSourceGenerator
+{
+    /// <summary>
+    /// Generates a ToDateOnly() method on types with semanticType="LocalMktDate"
+    /// (days since Unix epoch) and composites with semanticType="MonthYear".
+    /// </summary>
+    public record DateHelperDefinition : IFileContentGenerator
+    {
+        public string Namespace { get; }
+        public string Name { get; }
+        public DateHelperKind Kind { get; }
+
+        private DateHelperDefinition(string ns, string name, DateHelperKind kind)
+        {
+            Namespace = ns;
+            Name = name;
+            Kind = kind;
+        }
+
+        public static DateHelperDefinition LocalMktDate(string ns, string name) =>
+            new(ns, name, DateHelperKind.LocalMktDate);
+
+        public static DateHelperDefinition LocalMktDateOptional(string ns, string name) =>
+            new(ns, name, DateHelperKind.LocalMktDateOptional);
+
+        public static DateHelperDefinition MonthYear(string ns, string name, bool yearOptional, bool monthOptional, bool hasDay) =>
+            new(ns, name, DateHelperKind.MonthYear)
+            {
+                YearOptional = yearOptional,
+                MonthOptional = monthOptional,
+                HasDay = hasDay
+            };
+
+        public bool YearOptional { get; private init; }
+        public bool MonthOptional { get; private init; }
+        public bool HasDay { get; private init; }
+
+        public void AppendFileContent(StringBuilder sb, int tabs = 0)
+        {
+            sb.AppendTabs(tabs).Append("namespace ").Append(Namespace).AppendLine(";");
+            sb.AppendTabs(tabs).Append("public partial struct ").Append(Name).AppendLine();
+            sb.AppendLine("{", tabs++);
+
+            switch (Kind)
+            {
+                case DateHelperKind.LocalMktDate:
+                    sb.AppendLine("/// <summary>Converts days since Unix epoch to DateOnly.</summary>", tabs);
+                    sb.AppendLine("public readonly System.DateOnly ToDateOnly() => System.DateOnly.FromDateTime(System.DateTime.UnixEpoch.AddDays(Value));", tabs);
+                    break;
+                case DateHelperKind.LocalMktDateOptional:
+                    sb.AppendLine("/// <summary>Converts days since Unix epoch to DateOnly. Returns null if the value is null.</summary>", tabs);
+                    sb.AppendLine("public readonly System.DateOnly? ToDateOnly() => Value.HasValue ? System.DateOnly.FromDateTime(System.DateTime.UnixEpoch.AddDays(Value.Value)) : null;", tabs);
+                    break;
+                case DateHelperKind.MonthYear:
+                    AppendMonthYearToDateOnly(sb, tabs);
+                    break;
+            }
+
+            sb.AppendLine("}", --tabs);
+        }
+
+        private void AppendMonthYearToDateOnly(StringBuilder sb, int tabs)
+        {
+            sb.AppendLine("/// <summary>Converts to DateOnly using year, month, and day (defaults day to 1 if not set). Returns null if year or month is not set.</summary>", tabs);
+
+            var yearAccess = YearOptional ? "Year" : "(ushort?)Year";
+            var monthAccess = MonthOptional ? "Month" : "(byte?)Month";
+            var dayExpr = HasDay ? "Day ?? 1" : "1";
+
+            sb.AppendTabs(tabs).Append("public readonly System.DateOnly? ToDateOnly() => ")
+                .Append(yearAccess).Append(" is { } y && ").Append(monthAccess).Append(" is { } m ? new System.DateOnly(y, m, ").Append(dayExpr).AppendLine(") : null;");
+        }
+    }
+
+    public enum DateHelperKind
+    {
+        LocalMktDate,
+        LocalMktDateOptional,
+        MonthYear
+    }
+}

--- a/src/SbeCodeGenerator/Generators/Types/DecimalHelperDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Types/DecimalHelperDefinition.cs
@@ -1,0 +1,40 @@
+﻿using System.Text;
+
+namespace SbeSourceGenerator
+{
+    /// <summary>
+    /// Generates a ToDecimal() method on composites that match the SBE decimal pattern
+    /// (mantissa field + constant exponent field).
+    /// </summary>
+    public record DecimalHelperDefinition(string Namespace, string Name, string Description,
+        int Exponent, bool IsOptionalMantissa) : IFileContentGenerator
+    {
+        public void AppendFileContent(StringBuilder sb, int tabs = 0)
+        {
+            sb.AppendTabs(tabs).Append("namespace ").Append(Namespace).AppendLine(";");
+            sb.AppendTabs(tabs).Append("public partial struct ").Append(Name).AppendLine();
+            sb.AppendLine("{", tabs++);
+
+            var exponentStr = Exponent.ToString();
+            var multiplier = $"1e{exponentStr}m";
+
+            if (IsOptionalMantissa)
+            {
+                sb.AppendLine("/// <summary>", tabs);
+                sb.AppendTabs(tabs).Append("/// Converts the mantissa to a decimal using the constant exponent (10^").Append(exponentStr).AppendLine(").");
+                sb.AppendLine("/// Returns null if the mantissa is null (optional field).", tabs);
+                sb.AppendLine("/// </summary>", tabs);
+                sb.AppendTabs(tabs).Append("public readonly decimal? ToDecimal() => Mantissa.HasValue ? Mantissa.Value * ").Append(multiplier).AppendLine(" : null;");
+            }
+            else
+            {
+                sb.AppendLine("/// <summary>", tabs);
+                sb.AppendTabs(tabs).Append("/// Converts the mantissa to a decimal using the constant exponent (10^").Append(exponentStr).AppendLine(").");
+                sb.AppendLine("/// </summary>", tabs);
+                sb.AppendTabs(tabs).Append("public readonly decimal ToDecimal() => Mantissa * ").Append(multiplier).AppendLine(";");
+            }
+
+            sb.AppendLine("}", --tabs);
+        }
+    }
+}

--- a/src/SbeCodeGenerator/Generators/Types/FixedSizeCharTypeDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Types/FixedSizeCharTypeDefinition.cs
@@ -34,7 +34,7 @@ namespace SbeSourceGenerator
                 // AsSpan() — zero-allocation trimmed content access
                 sb.AppendLine("/// <summary>Returns the trimmed content as a ReadOnlySpan&lt;byte&gt; (zero-allocation). Excludes null-termination padding.</summary>", tabs);
                 sb.AppendLine("[System.Diagnostics.CodeAnalysis.UnscopedRef]", tabs);
-                sb.AppendLine("public ReadOnlySpan<byte> AsSpan()", tabs);
+                sb.AppendLine("public readonly ReadOnlySpan<byte> AsSpan()", tabs);
                 sb.AppendLine("{", tabs++);
                 sb.AppendLine("ReadOnlySpan<byte> span = this;", tabs);
                 sb.AppendTabs(tabs).AppendLine("var index = span.IndexOf((byte)0);");
@@ -43,10 +43,10 @@ namespace SbeSourceGenerator
 
                 // Equals(ReadOnlySpan<byte>) — zero-allocation comparison
                 sb.AppendLine("/// <summary>Compares the content to a byte span without allocation. Useful with UTF-8 string literals: symbol.Equals(\"PETR4\"u8)</summary>", tabs);
-                sb.AppendLine("public bool Equals(ReadOnlySpan<byte> other) => AsSpan().SequenceEqual(other);", tabs);
+                sb.AppendLine("public readonly bool Equals(ReadOnlySpan<byte> other) => AsSpan().SequenceEqual(other);", tabs);
 
                 // ToString() — delegates to AsSpan()
-                sb.AppendTabs(tabs).Append("public override string ToString() => System.Text.").Append(ResolvedEncoding).AppendLine(".GetString(AsSpan());");
+                sb.AppendTabs(tabs).Append("public readonly override string ToString() => System.Text.").Append(ResolvedEncoding).AppendLine(".GetString(AsSpan());");
                 sb.AppendLine("}", --tabs);
             }
         }

--- a/src/SbeCodeGenerator/Generators/Types/FixedSizeCharTypeDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Types/FixedSizeCharTypeDefinition.cs
@@ -30,12 +30,23 @@ namespace SbeSourceGenerator
                 sb.AppendTabs(tabs).Append("public struct ").Append(Name).AppendLine();
                 sb.AppendLine("{", tabs++);
                 sb.AppendLine("private byte value;", tabs);
-                sb.AppendLine("public override string ToString()", tabs);
+
+                // AsSpan() — zero-allocation trimmed content access
+                sb.AppendLine("/// <summary>Returns the trimmed content as a ReadOnlySpan&lt;byte&gt; (zero-allocation). Excludes null-termination padding.</summary>", tabs);
+                sb.AppendLine("[System.Diagnostics.CodeAnalysis.UnscopedRef]", tabs);
+                sb.AppendLine("public ReadOnlySpan<byte> AsSpan()", tabs);
                 sb.AppendLine("{", tabs++);
                 sb.AppendLine("ReadOnlySpan<byte> span = this;", tabs);
                 sb.AppendTabs(tabs).AppendLine("var index = span.IndexOf((byte)0);");
-                sb.AppendTabs(tabs).Append("return System.Text.").Append(ResolvedEncoding).Append(".GetString(span.Slice(0, index == -1 ? ").Append(Length).AppendLine(" : index));");
+                sb.AppendTabs(tabs).Append("return span.Slice(0, index == -1 ? ").Append(Length).AppendLine(" : index);");
                 sb.AppendLine("}", --tabs);
+
+                // Equals(ReadOnlySpan<byte>) — zero-allocation comparison
+                sb.AppendLine("/// <summary>Compares the content to a byte span without allocation. Useful with UTF-8 string literals: symbol.Equals(\"PETR4\"u8)</summary>", tabs);
+                sb.AppendLine("public bool Equals(ReadOnlySpan<byte> other) => AsSpan().SequenceEqual(other);", tabs);
+
+                // ToString() — delegates to AsSpan()
+                sb.AppendTabs(tabs).Append("public override string ToString() => System.Text.").Append(ResolvedEncoding).AppendLine(".GetString(AsSpan());");
                 sb.AppendLine("}", --tabs);
             }
         }

--- a/src/SbeCodeGenerator/Generators/Types/MessageDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Types/MessageDefinition.cs
@@ -122,7 +122,7 @@ namespace SbeSourceGenerator
             sb.AppendLine("/// <param name=\"bytesWritten\">Number of bytes written on success.</param>", tabs);
             sb.AppendLine("/// <returns>True if encoding succeeded; otherwise, false.</returns>", tabs);
             sb.AppendLine("[MethodImpl(MethodImplOptions.AggressiveInlining)]", tabs);
-            sb.AppendTabs(tabs).AppendLine("public bool TryEncode(Span<byte> buffer, out int bytesWritten)");
+            sb.AppendTabs(tabs).AppendLine("public readonly bool TryEncode(Span<byte> buffer, out int bytesWritten)");
             sb.AppendLine("{", tabs++);
             sb.AppendLine("if (buffer.Length < MESSAGE_SIZE)", tabs);
             sb.AppendLine("{", tabs++);
@@ -144,7 +144,7 @@ namespace SbeSourceGenerator
             sb.AppendLine("/// <param name=\"writer\">The writer to use.</param>", tabs);
             sb.AppendLine("/// <returns>True if encoding succeeded; otherwise, false.</returns>", tabs);
             sb.AppendLine("[MethodImpl(MethodImplOptions.AggressiveInlining)]", tabs);
-            sb.AppendTabs(tabs).AppendLine("public bool TryEncodeWithWriter(ref SpanWriter writer)");
+            sb.AppendTabs(tabs).AppendLine("public readonly bool TryEncodeWithWriter(ref SpanWriter writer)");
             sb.AppendLine("{", tabs++);
             sb.AppendLine("return writer.TryWrite(this);", tabs);
             sb.AppendLine("}", --tabs);
@@ -157,7 +157,7 @@ namespace SbeSourceGenerator
             sb.AppendLine("/// <param name=\"buffer\">The destination buffer.</param>", tabs);
             sb.AppendLine("/// <returns>Number of bytes written.</returns>", tabs);
             sb.AppendLine("/// <exception cref=\"InvalidOperationException\">Thrown when buffer is too small.</exception>", tabs);
-            sb.AppendTabs(tabs).AppendLine("public int Encode(Span<byte> buffer)");
+            sb.AppendTabs(tabs).AppendLine("public readonly int Encode(Span<byte> buffer)");
             sb.AppendLine("{", tabs++);
             sb.AppendLine("if (!TryEncode(buffer, out int bytesWritten))", tabs);
             sb.AppendTabs(tabs).Append("    throw new InvalidOperationException($\"Failed to encode ").Append(Name).AppendLine("Data. Buffer size: {buffer.Length}, Required: {MESSAGE_SIZE}\");");

--- a/src/SbeCodeGenerator/Generators/Types/OptionalTypeDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Types/OptionalTypeDefinition.cs
@@ -15,9 +15,10 @@ namespace SbeSourceGenerator
             sb.AppendSummary(Description, tabs, nameof(OptionalTypeDefinition));
             sb.AppendTabs(tabs).Append("public partial struct ").Append(Name).AppendLine();
             sb.AppendLine("{", tabs++);
+            NullableValueFieldDefinition.AppendNullConstant(sb, tabs, PrimitiveType, "ValueNullValue", nullValue);
             sb.AppendTabs(tabs).Append("private ").Append(PrimitiveType).AppendLine(" value;");
             sb.AppendTabs(tabs).Append("public ").Append(PrimitiveType).Append("? Value");
-            NullableValueFieldDefinition.AppendNullCheck(sb, PrimitiveType, "value", nullValue);
+            NullableValueFieldDefinition.AppendNullCheck(sb, PrimitiveType, "value", nullValue, "ValueNullValue");
             sb.AppendLine("}", --tabs);
             sb.AppendLine("#pragma warning restore CS0649", tabs);
         }

--- a/src/SbeCodeGenerator/Generators/Types/TimestampHelperDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Types/TimestampHelperDefinition.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Text;
+
+namespace SbeSourceGenerator
+{
+    public enum TimeUnitKind
+    {
+        Nanosecond,
+        Microsecond,
+        Millisecond,
+        Second
+    }
+
+    /// <summary>
+    /// Generates ToDateTime() and ToDateTimeOffset() methods on composites that match
+    /// the SBE timestamp pattern (time field + constant unit field).
+    /// </summary>
+    public record TimestampHelperDefinition(string Namespace, string Name, string Description,
+        TimeUnitKind Unit, bool IsOptionalTime) : IFileContentGenerator
+    {
+        public void AppendFileContent(StringBuilder sb, int tabs = 0)
+        {
+            sb.AppendTabs(tabs).Append("namespace ").Append(Namespace).AppendLine(";");
+            sb.AppendTabs(tabs).Append("public partial struct ").Append(Name).AppendLine();
+            sb.AppendLine("{", tabs++);
+
+            AppendToDateTime(sb, tabs);
+            AppendToDateTimeOffset(sb, tabs);
+
+            sb.AppendLine("}", --tabs);
+        }
+
+        private void AppendToDateTime(StringBuilder sb, int tabs)
+        {
+            var unitLabel = Unit switch
+            {
+                TimeUnitKind.Nanosecond => "nanoseconds",
+                TimeUnitKind.Microsecond => "microseconds",
+                TimeUnitKind.Millisecond => "milliseconds",
+                TimeUnitKind.Second => "seconds",
+                _ => "units"
+            };
+
+            sb.AppendLine("/// <summary>", tabs);
+            sb.AppendTabs(tabs).Append("/// Converts ").Append(unitLabel).AppendLine(" since Unix epoch to DateTime (UTC).");
+            if (IsOptionalTime)
+                sb.AppendLine("/// Returns null if the time field is null.", tabs);
+            sb.AppendLine("/// </summary>", tabs);
+
+            if (IsOptionalTime)
+            {
+                sb.AppendTabs(tabs).Append("public readonly System.DateTime? ToDateTime() => Time.HasValue ? ");
+                AppendConversionExpression(sb, "Time.Value", "System.DateTime");
+                sb.AppendLine(" : null;");
+            }
+            else
+            {
+                sb.AppendTabs(tabs).Append("public readonly System.DateTime ToDateTime() => ");
+                AppendConversionExpression(sb, "Time", "System.DateTime");
+                sb.AppendLine(";");
+            }
+        }
+
+        private void AppendToDateTimeOffset(StringBuilder sb, int tabs)
+        {
+            var unitLabel = Unit switch
+            {
+                TimeUnitKind.Nanosecond => "nanoseconds",
+                TimeUnitKind.Microsecond => "microseconds",
+                TimeUnitKind.Millisecond => "milliseconds",
+                TimeUnitKind.Second => "seconds",
+                _ => "units"
+            };
+
+            sb.AppendLine("/// <summary>", tabs);
+            sb.AppendTabs(tabs).Append("/// Converts ").Append(unitLabel).AppendLine(" since Unix epoch to DateTimeOffset (UTC).");
+            if (IsOptionalTime)
+                sb.AppendLine("/// Returns null if the time field is null.", tabs);
+            sb.AppendLine("/// </summary>", tabs);
+
+            if (IsOptionalTime)
+            {
+                sb.AppendTabs(tabs).Append("public readonly System.DateTimeOffset? ToDateTimeOffset() => Time.HasValue ? ");
+                AppendConversionExpression(sb, "Time.Value", "System.DateTimeOffset");
+                sb.AppendLine(" : null;");
+            }
+            else
+            {
+                sb.AppendTabs(tabs).Append("public readonly System.DateTimeOffset ToDateTimeOffset() => ");
+                AppendConversionExpression(sb, "Time", "System.DateTimeOffset");
+                sb.AppendLine(";");
+            }
+        }
+
+        private void AppendConversionExpression(StringBuilder sb, string timeAccess, string targetType)
+        {
+            switch (Unit)
+            {
+                case TimeUnitKind.Nanosecond:
+                    sb.Append(targetType).Append(".UnixEpoch.AddTicks((long)(").Append(timeAccess).Append(" / 100))");
+                    break;
+                case TimeUnitKind.Microsecond:
+                    sb.Append(targetType).Append(".UnixEpoch.AddTicks((long)(").Append(timeAccess).Append(" * 10))");
+                    break;
+                case TimeUnitKind.Millisecond:
+                    sb.Append("System.DateTimeOffset.FromUnixTimeMilliseconds((long)").Append(timeAccess).Append(")");
+                    if (targetType == "System.DateTime")
+                        sb.Append(".UtcDateTime");
+                    break;
+                case TimeUnitKind.Second:
+                    sb.Append("System.DateTimeOffset.FromUnixTimeSeconds((long)").Append(timeAccess).Append(")");
+                    if (targetType == "System.DateTime")
+                        sb.Append(".UtcDateTime");
+                    break;
+            }
+        }
+    }
+}

--- a/src/SbeCodeGenerator/Generators/TypesCodeGenerator.cs
+++ b/src/SbeCodeGenerator/Generators/TypesCodeGenerator.cs
@@ -183,6 +183,16 @@ namespace SbeSourceGenerator.Generators
                 generator.AppendFileContent(sb);
                 yield return (context.CreateHintName(ns, "Types", generatedName), sb.ToString());
 
+                // Detect LocalMktDate pattern on simple types
+                if (string.Equals(typeDto.SemanticType, "LocalMktDate", System.StringComparison.OrdinalIgnoreCase))
+                {
+                    var dateHelper = generator is OptionalTypeDefinition
+                        ? DateHelperDefinition.LocalMktDateOptional(ns, generatedName)
+                        : DateHelperDefinition.LocalMktDate(ns, generatedName);
+                    sb.Clear();
+                    dateHelper.AppendFileContent(sb);
+                    yield return (context.CreateHintName(ns, "Types", generatedName + ".ToDateOnly"), sb.ToString());
+                }
             }
         }
 
@@ -422,6 +432,15 @@ namespace SbeSourceGenerator.Generators
                 timestampHelper.AppendFileContent(sb);
                 yield return (context.CreateHintName(ns, "Composites", generatedName + ".ToDateTime"), sb.ToString());
             }
+
+            // Detect MonthYear pattern: semanticType="MonthYear" with year/month fields
+            var monthYearHelper = TryCreateMonthYearHelper(ns, generatedName, compositeDto);
+            if (monthYearHelper != null)
+            {
+                sb.Clear();
+                monthYearHelper.AppendFileContent(sb);
+                yield return (context.CreateHintName(ns, "Composites", generatedName + ".ToDateOnly"), sb.ToString());
+            }
         }
 
         private static string InsertQuotationsIfNeeded(string innerText, string type, string length)
@@ -506,6 +525,34 @@ namespace SbeSourceGenerator.Generators
             }
 
             return null;
+        }
+
+        private static DateHelperDefinition? TryCreateMonthYearHelper(string ns, string generatedName, SchemaCompositeDto compositeDto)
+        {
+            if (!string.Equals(compositeDto.SemanticType, "MonthYear", System.StringComparison.OrdinalIgnoreCase))
+                return null;
+
+            SchemaFieldDto? yearField = null;
+            SchemaFieldDto? monthField = null;
+            bool hasDay = false;
+
+            foreach (var field in compositeDto.Fields)
+            {
+                if (string.Equals(field.Name, "year", System.StringComparison.OrdinalIgnoreCase))
+                    yearField = field;
+                else if (string.Equals(field.Name, "month", System.StringComparison.OrdinalIgnoreCase))
+                    monthField = field;
+                else if (string.Equals(field.Name, "day", System.StringComparison.OrdinalIgnoreCase))
+                    hasDay = true;
+            }
+
+            if (yearField == null || monthField == null)
+                return null;
+
+            return DateHelperDefinition.MonthYear(ns, generatedName,
+                yearOptional: yearField.Presence == "optional",
+                monthOptional: monthField.Presence == "optional",
+                hasDay: hasDay);
         }
     }
 }

--- a/src/SbeCodeGenerator/Generators/TypesCodeGenerator.cs
+++ b/src/SbeCodeGenerator/Generators/TypesCodeGenerator.cs
@@ -316,6 +316,7 @@ namespace SbeSourceGenerator.Generators
                     var charTypeName = TypeResolverHelper.RegisterGeneratedTypeName(context, ft.Field.Name, sourceContext);
                     var charTypeDef = new FixedSizeCharTypeDefinition(ns, charTypeName, ft.Field.Description, charLen, ft.Field.CharacterEncoding);
                     context.CustomTypeLengths[ft.Field.Name] = charLen;
+                    context.StructTypeNames.Add(ft.Field.Name);
                     charArrayTypes[ft.Field.Name] = (charTypeName, charLen);
                     var charSb = new StringBuilder(256);
                     charTypeDef.AppendFileContent(charSb);
@@ -399,6 +400,7 @@ namespace SbeSourceGenerator.Generators
             );
             if (generator.Fields.All(f => f is IBlittable))
                 context.CustomTypeLengths[compositeDto.Name] = generator.Fields.SumFieldLength();
+            context.StructTypeNames.Add(compositeDto.Name);
             StringBuilder sb = new StringBuilder(1024);
             generator.AppendFileContent(sb);
             yield return (context.CreateHintName(ns, "Composites", generatedName), sb.ToString());

--- a/src/SbeCodeGenerator/Generators/TypesCodeGenerator.cs
+++ b/src/SbeCodeGenerator/Generators/TypesCodeGenerator.cs
@@ -413,6 +413,15 @@ namespace SbeSourceGenerator.Generators
                 decimalHelper.AppendFileContent(sb);
                 yield return (context.CreateHintName(ns, "Composites", generatedName + ".ToDecimal"), sb.ToString());
             }
+
+            // Detect timestamp pattern: time field + constant unit field
+            var timestampHelper = TryCreateTimestampHelper(ns, generatedName, compositeDto);
+            if (timestampHelper != null)
+            {
+                sb.Clear();
+                timestampHelper.AppendFileContent(sb);
+                yield return (context.CreateHintName(ns, "Composites", generatedName + ".ToDateTime"), sb.ToString());
+            }
         }
 
         private static string InsertQuotationsIfNeeded(string innerText, string type, string length)
@@ -449,6 +458,54 @@ namespace SbeSourceGenerator.Generators
 
             bool isOptional = mantissaField.Presence == "optional";
             return new DecimalHelperDefinition(ns, generatedName, compositeDto.Description, exponent, isOptional);
+        }
+
+        private static TimestampHelperDefinition? TryCreateTimestampHelper(string ns, string generatedName, SchemaCompositeDto compositeDto)
+        {
+            SchemaFieldDto? timeField = null;
+            SchemaFieldDto? unitField = null;
+
+            foreach (var field in compositeDto.Fields)
+            {
+                if (string.Equals(field.Name, "time", System.StringComparison.OrdinalIgnoreCase)
+                    && !string.IsNullOrEmpty(field.PrimitiveType))
+                    timeField = field;
+                else if (string.Equals(field.Name, "unit", System.StringComparison.OrdinalIgnoreCase)
+                    && field.Presence == "constant")
+                    unitField = field;
+            }
+
+            if (timeField == null || unitField == null)
+                return null;
+
+            var unit = ResolveTimeUnit(unitField);
+            if (unit == null)
+                return null;
+
+            bool isOptional = timeField.Presence == "optional";
+            return new TimestampHelperDefinition(ns, generatedName, compositeDto.Description, unit.Value, isOptional);
+        }
+
+        private static TimeUnitKind? ResolveTimeUnit(SchemaFieldDto unitField)
+        {
+            // Try valueRef first (e.g., "TimeUnit.nanosecond")
+            var valueRef = unitField.ValueRef ?? "";
+            var dotIndex = valueRef.LastIndexOf('.');
+            var valueName = dotIndex >= 0 ? valueRef.Substring(dotIndex + 1) : valueRef;
+
+            if (!string.IsNullOrEmpty(valueName))
+            {
+                if (valueName.IndexOf("nanosecond", System.StringComparison.OrdinalIgnoreCase) >= 0)
+                    return TimeUnitKind.Nanosecond;
+                if (valueName.IndexOf("microsecond", System.StringComparison.OrdinalIgnoreCase) >= 0)
+                    return TimeUnitKind.Microsecond;
+                if (valueName.IndexOf("millisecond", System.StringComparison.OrdinalIgnoreCase) >= 0)
+                    return TimeUnitKind.Millisecond;
+                if (valueName.IndexOf("second", System.StringComparison.OrdinalIgnoreCase) >= 0)
+                    return TimeUnitKind.Second;
+            }
+
+            return null;
         }
     }
 }

--- a/src/SbeCodeGenerator/Generators/TypesCodeGenerator.cs
+++ b/src/SbeCodeGenerator/Generators/TypesCodeGenerator.cs
@@ -404,6 +404,15 @@ namespace SbeSourceGenerator.Generators
             StringBuilder sb = new StringBuilder(1024);
             generator.AppendFileContent(sb);
             yield return (context.CreateHintName(ns, "Composites", generatedName), sb.ToString());
+
+            // Detect decimal pattern: mantissa field + constant exponent field
+            var decimalHelper = TryCreateDecimalHelper(ns, generatedName, compositeDto);
+            if (decimalHelper != null)
+            {
+                sb.Clear();
+                decimalHelper.AppendFileContent(sb);
+                yield return (context.CreateHintName(ns, "Composites", generatedName + ".ToDecimal"), sb.ToString());
+            }
         }
 
         private static string InsertQuotationsIfNeeded(string innerText, string type, string length)
@@ -416,5 +425,30 @@ namespace SbeSourceGenerator.Generators
             };
         }
 
+        private static DecimalHelperDefinition? TryCreateDecimalHelper(string ns, string generatedName, SchemaCompositeDto compositeDto)
+        {
+            SchemaFieldDto mantissaField = null;
+            SchemaFieldDto exponentField = null;
+
+            foreach (var field in compositeDto.Fields)
+            {
+                if (string.Equals(field.Name, "mantissa", System.StringComparison.OrdinalIgnoreCase)
+                    && !string.IsNullOrEmpty(field.PrimitiveType))
+                    mantissaField = field;
+                else if (string.Equals(field.Name, "exponent", System.StringComparison.OrdinalIgnoreCase)
+                    && field.Presence == "constant"
+                    && !string.IsNullOrEmpty(field.InnerText))
+                    exponentField = field;
+            }
+
+            if (mantissaField == null || exponentField == null)
+                return null;
+
+            if (!int.TryParse(exponentField.InnerText, out var exponent))
+                return null;
+
+            bool isOptional = mantissaField.Presence == "optional";
+            return new DecimalHelperDefinition(ns, generatedName, compositeDto.Description, exponent, isOptional);
+        }
     }
 }

--- a/src/SbeCodeGenerator/SbeSourceGenerator.csproj
+++ b/src/SbeCodeGenerator/SbeSourceGenerator.csproj
@@ -11,7 +11,7 @@
 		<IncludeBuildOutput>false</IncludeBuildOutput>
 		<PackageId>SbeSourceGenerator</PackageId>
 		<Title>SBE Source Generator</Title>
-		<Version>1.0.2</Version>
+		<Version>1.1.0</Version>
 		<Authors>Pedro Sakuma</Authors>
 		<Company>Pedro Sakuma</Company>
 		<Product>SBE Source Generator</Product>

--- a/src/SbeCodeGenerator/SchemaContext.cs
+++ b/src/SbeCodeGenerator/SchemaContext.cs
@@ -62,6 +62,12 @@ namespace SbeSourceGenerator
         public Dictionary<string, string> CompositeFieldTypes { get; } = new Dictionary<string, string>(16);
 
         /// <summary>
+        /// Tracks struct types (composites, InlineArray char types) by their original schema name.
+        /// Used to detect fields that need ref-returning properties instead of value properties.
+        /// </summary>
+        public HashSet<string> StructTypeNames { get; } = new HashSet<string>();
+
+        /// <summary>
         /// The byte order (endianness) specified in the schema.
         /// Defaults to "littleEndian" if not specified.
         /// </summary>

--- a/tests/SbeCodeGenerator.Tests/EndianTests.cs
+++ b/tests/SbeCodeGenerator.Tests/EndianTests.cs
@@ -86,12 +86,14 @@ namespace SbeCodeGenerator.Tests
         }
 
         [Fact]
-        public void AppendField_None_EmitsPublicField()
+        public void AppendField_None_EmitsPrivateFieldAndProperty()
         {
             var sb = new StringBuilder();
             EndianFieldHelper.AppendField(sb, 0, "int", "Price", EndianConversion.None);
-            Assert.Contains("public int Price;", sb.ToString());
-            Assert.DoesNotContain("private", sb.ToString());
+            var result = sb.ToString();
+            Assert.Contains("private int price;", result);
+            Assert.Contains("readonly get => price", result);
+            Assert.Contains("set => price = value;", result);
         }
 
         [Fact]
@@ -101,7 +103,7 @@ namespace SbeCodeGenerator.Tests
             EndianFieldHelper.AppendField(sb, 0, "int", "Price", EndianConversion.AlwaysReverse);
             var result = sb.ToString();
             Assert.Contains("private int price;", result);
-            Assert.Contains("public int Price", result);
+            Assert.Contains("readonly get => ", result);
             Assert.Contains("BinaryPrimitives.ReverseEndianness(price)", result);
         }
 
@@ -117,12 +119,14 @@ namespace SbeCodeGenerator.Tests
         }
 
         [Fact]
-        public void AppendField_SingleByte_AlwaysPassthrough()
+        public void AppendField_SingleByte_AlwaysPrivateWithProperty()
         {
             var sb = new StringBuilder();
             EndianFieldHelper.AppendField(sb, 0, "byte", "Tag", EndianConversion.AlwaysReverse);
-            Assert.Contains("public byte Tag;", sb.ToString());
-            Assert.DoesNotContain("private", sb.ToString());
+            var result = sb.ToString();
+            Assert.Contains("private byte tag;", result);
+            Assert.Contains("readonly get => tag", result);
+            Assert.Contains("set => tag = value;", result);
         }
 
         [Fact]
@@ -137,13 +141,15 @@ namespace SbeCodeGenerator.Tests
         }
 
         [Fact]
-        public void AppendMessageField_None_EmitsPublicField()
+        public void AppendMessageField_None_EmitsPrivateFieldAndProperty()
         {
             var sb = new StringBuilder();
             EndianFieldHelper.AppendMessageField(sb, 0, "uint", "uint", "Price", 4, EndianConversion.None);
             var result = sb.ToString();
             Assert.Contains("[FieldOffset(4)]", result);
-            Assert.Contains("public uint Price;", result);
+            Assert.Contains("private uint price;", result);
+            Assert.Contains("readonly get => price", result);
+            Assert.Contains("set => price = value;", result);
         }
 
         [Fact]
@@ -216,8 +222,9 @@ namespace SbeCodeGenerator.Tests
             Assert.Contains("BinaryPrimitives.ReverseEndianness", content);
             Assert.Contains("private uint", content);
             Assert.Contains("private ulong", content);
-            Assert.Contains("public uint Price", content);
-            Assert.Contains("public ulong Quantity", content);
+            Assert.Contains("readonly get =>", content);
+            Assert.Contains("uint Price", content);
+            Assert.Contains("ulong Quantity", content);
             Assert.Contains("using System.Buffers.Binary;", content);
         }
 
@@ -237,8 +244,10 @@ namespace SbeCodeGenerator.Tests
 
             var results = generator.Generate("TestNs", schema, context, default(SourceProductionContext)).ToList();
             var content = results[0].content;
-            Assert.Contains("public uint Price;", content);
-            Assert.Contains("public ulong Quantity;", content);
+            Assert.Contains("private uint price;", content);
+            Assert.Contains("readonly get => price", content);
+            Assert.Contains("private ulong quantity;", content);
+            Assert.Contains("readonly get => quantity", content);
             Assert.DoesNotContain("BinaryPrimitives.ReverseEndianness", content);
         }
 
@@ -260,8 +269,9 @@ namespace SbeCodeGenerator.Tests
 
             var results = generator.Generate("TestNs", schema, context, default(SourceProductionContext)).ToList();
             var content = results[0].content;
-            // Single byte field should be a public field
-            Assert.Contains("public byte Tag;", content);
+            // Single byte field should use private backing + property
+            Assert.Contains("private byte tag;", content);
+            Assert.Contains("readonly get => tag", content);
             // Multi-byte field should use endian conversion
             Assert.Contains("private uint", content);
         }
@@ -373,8 +383,9 @@ namespace SbeCodeGenerator.Tests
             var results = messagesGen.Generate("TestNs", schema, context, default(SourceProductionContext)).ToList();
             var content = results[0].content;
 
-            // byte-backed enum should NOT have endian conversion
-            Assert.Contains("public Side Side;", content);
+            // byte-backed enum should use private backing + property (no endian conversion)
+            Assert.Contains("private Side side;", content);
+            Assert.Contains("readonly get => side", content);
             Assert.DoesNotContain("BinaryPrimitives.ReverseEndianness", content);
         }
 

--- a/tests/SbeCodeGenerator.Tests/MessagesCodeGeneratorTests.cs
+++ b/tests/SbeCodeGenerator.Tests/MessagesCodeGeneratorTests.cs
@@ -725,7 +725,9 @@ namespace SbeCodeGenerator.Tests
             var msgResult = results.First(r => r.name.Contains("TestMessage"));
 
             // Assert - should be a regular field (not optional), composites handle their own null semantics
-            Assert.Contains("public PriceOptional Price;", msgResult.content);
+            Assert.Contains("private PriceOptional price;", msgResult.content);
+            Assert.Contains("[System.Diagnostics.CodeAnalysis.UnscopedRef]", msgResult.content);
+            Assert.Contains("public ref PriceOptional Price => ref price;", msgResult.content);
             Assert.DoesNotContain("PriceOptional?", msgResult.content); // No nullable
             Assert.DoesNotContain("== default", msgResult.content); // No default comparison
         }

--- a/tests/SbeCodeGenerator.Tests/MessagesCodeGeneratorTests.cs
+++ b/tests/SbeCodeGenerator.Tests/MessagesCodeGeneratorTests.cs
@@ -568,10 +568,12 @@ namespace SbeCodeGenerator.Tests
             var msgResult = results.FirstOrDefault(r => r.name.Contains("OrderWithCustomNull"));
             Assert.NotEqual(default, msgResult);
 
-            // Should use custom nullValue=0 instead of default -9223372036854775808L
-            Assert.Contains("== 0", msgResult.content);
-            // Should use custom nullValue=-1 instead of default -2147483648
-            Assert.Contains("== -1", msgResult.content);
+            // Should use custom nullValue=0 via named constant PriceNullValue
+            Assert.Contains("PriceNullValue", msgResult.content);
+            Assert.Contains("== PriceNullValue", msgResult.content);
+            // Should use custom nullValue=-1 via named constant QuantityNullValue
+            Assert.Contains("QuantityNullValue", msgResult.content);
+            Assert.Contains("== QuantityNullValue", msgResult.content);
         }
 
         [Fact]
@@ -688,10 +690,11 @@ namespace SbeCodeGenerator.Tests
             var results = generator.Generate("TestNs", schema, context, default(SourceProductionContext));
             var msgResult = results.First(r => r.name.Contains("TestMessage"));
 
-            // Assert - should use uint (not RptSeq struct) and nullValue=0
+            // Assert - should use uint (not RptSeq struct) and nullValue=0 via named constant
             Assert.Contains("private uint rptSeq;", msgResult.content);
             Assert.Contains("uint?", msgResult.content);
-            Assert.Contains("== 0", msgResult.content);
+            Assert.Contains("RptSeqNullValue", msgResult.content);
+            Assert.Contains("== RptSeqNullValue", msgResult.content);
         }
 
         [Fact]

--- a/tests/SbeCodeGenerator.Tests/Snapshots/MessagesCodeGenerator.Message.Quote.verified.txt
+++ b/tests/SbeCodeGenerator.Tests/Snapshots/MessagesCodeGenerator.Message.Quote.verified.txt
@@ -88,7 +88,7 @@ public partial struct QuoteData
 	/// <param name="bytesWritten">Number of bytes written on success.</param>
 	/// <returns>True if encoding succeeded; otherwise, false.</returns>
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public bool TryEncode(Span<byte> buffer, out int bytesWritten)
+	public readonly bool TryEncode(Span<byte> buffer, out int bytesWritten)
 	{
 		if (buffer.Length < MESSAGE_SIZE)
 		{
@@ -108,7 +108,7 @@ public partial struct QuoteData
 	/// <param name="writer">The writer to use.</param>
 	/// <returns>True if encoding succeeded; otherwise, false.</returns>
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public bool TryEncodeWithWriter(ref SpanWriter writer)
+	public readonly bool TryEncodeWithWriter(ref SpanWriter writer)
 	{
 		return writer.TryWrite(this);
 	}
@@ -119,7 +119,7 @@ public partial struct QuoteData
 	/// <param name="buffer">The destination buffer.</param>
 	/// <returns>Number of bytes written.</returns>
 	/// <exception cref="InvalidOperationException">Thrown when buffer is too small.</exception>
-	public int Encode(Span<byte> buffer)
+	public readonly int Encode(Span<byte> buffer)
 	{
 		if (!TryEncode(buffer, out int bytesWritten))
 		    throw new InvalidOperationException($"Failed to encode QuoteData. Buffer size: {buffer.Length}, Required: {MESSAGE_SIZE}");

--- a/tests/SbeCodeGenerator.Tests/Snapshots/MessagesCodeGenerator.Message.Quote.verified.txt
+++ b/tests/SbeCodeGenerator.Tests/Snapshots/MessagesCodeGenerator.Message.Quote.verified.txt
@@ -30,25 +30,29 @@ public partial struct QuoteData
 	/// (MessageFieldDefinition)
 	/// </summary>
 	[FieldOffset(0)]
-	public long BidPrice;
+	private long bidPrice;
+	public long BidPrice { readonly get => bidPrice; set => bidPrice = value; }
 	/// <summary>
 	/// 
 	/// (MessageFieldDefinition)
 	/// </summary>
 	[FieldOffset(8)]
-	public long BidQuantity;
+	private long bidQuantity;
+	public long BidQuantity { readonly get => bidQuantity; set => bidQuantity = value; }
 	/// <summary>
 	/// 
 	/// (MessageFieldDefinition)
 	/// </summary>
 	[FieldOffset(16)]
-	public long AskPrice;
+	private long askPrice;
+	public long AskPrice { readonly get => askPrice; set => askPrice = value; }
 	/// <summary>
 	/// 
 	/// (MessageFieldDefinition)
 	/// </summary>
 	[FieldOffset(24)]
-	public long AskQuantity;
+	private long askQuantity;
+	public long AskQuantity { readonly get => askQuantity; set => askQuantity = value; }
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public static bool TryParse(ReadOnlySpan<byte> buffer, out QuoteDataReader reader)
 	{

--- a/tests/SbeCodeGenerator.Tests/Snapshots/MessagesCodeGenerator.Message.Trade.verified.txt
+++ b/tests/SbeCodeGenerator.Tests/Snapshots/MessagesCodeGenerator.Message.Trade.verified.txt
@@ -88,7 +88,7 @@ public partial struct TradeData
 	/// <param name="bytesWritten">Number of bytes written on success.</param>
 	/// <returns>True if encoding succeeded; otherwise, false.</returns>
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public bool TryEncode(Span<byte> buffer, out int bytesWritten)
+	public readonly bool TryEncode(Span<byte> buffer, out int bytesWritten)
 	{
 		if (buffer.Length < MESSAGE_SIZE)
 		{
@@ -108,7 +108,7 @@ public partial struct TradeData
 	/// <param name="writer">The writer to use.</param>
 	/// <returns>True if encoding succeeded; otherwise, false.</returns>
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public bool TryEncodeWithWriter(ref SpanWriter writer)
+	public readonly bool TryEncodeWithWriter(ref SpanWriter writer)
 	{
 		return writer.TryWrite(this);
 	}
@@ -119,7 +119,7 @@ public partial struct TradeData
 	/// <param name="buffer">The destination buffer.</param>
 	/// <returns>Number of bytes written.</returns>
 	/// <exception cref="InvalidOperationException">Thrown when buffer is too small.</exception>
-	public int Encode(Span<byte> buffer)
+	public readonly int Encode(Span<byte> buffer)
 	{
 		if (!TryEncode(buffer, out int bytesWritten))
 		    throw new InvalidOperationException($"Failed to encode TradeData. Buffer size: {buffer.Length}, Required: {MESSAGE_SIZE}");

--- a/tests/SbeCodeGenerator.Tests/Snapshots/MessagesCodeGenerator.Message.Trade.verified.txt
+++ b/tests/SbeCodeGenerator.Tests/Snapshots/MessagesCodeGenerator.Message.Trade.verified.txt
@@ -30,25 +30,29 @@ public partial struct TradeData
 	/// (MessageFieldDefinition)
 	/// </summary>
 	[FieldOffset(0)]
-	public long TradeId;
+	private long tradeId;
+	public long TradeId { readonly get => tradeId; set => tradeId = value; }
 	/// <summary>
 	/// 
 	/// (MessageFieldDefinition)
 	/// </summary>
 	[FieldOffset(8)]
-	public long Price;
+	private long price;
+	public long Price { readonly get => price; set => price = value; }
 	/// <summary>
 	/// 
 	/// (MessageFieldDefinition)
 	/// </summary>
 	[FieldOffset(16)]
-	public long Quantity;
+	private long quantity;
+	public long Quantity { readonly get => quantity; set => quantity = value; }
 	/// <summary>
 	/// 
 	/// (MessageFieldDefinition)
 	/// </summary>
 	[FieldOffset(24)]
-	public Side Side;
+	private Side side;
+	public Side Side { readonly get => side; set => side = value; }
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public static bool TryParse(ReadOnlySpan<byte> buffer, out TradeDataReader reader)
 	{

--- a/tests/SbeCodeGenerator.Tests/Snapshots/TypesCodeGenerator.Composite.MessageHeader.verified.txt
+++ b/tests/SbeCodeGenerator.Tests/Snapshots/TypesCodeGenerator.Composite.MessageHeader.verified.txt
@@ -24,22 +24,26 @@ public partial struct MessageHeader
 	/// 
 	/// (ValueFieldDefinition)
 	/// </summary>
-	public ushort BlockLength;
+	private ushort blockLength;
+	public ushort BlockLength { readonly get => blockLength; set => blockLength = value; }
 	/// <summary>
 	/// 
 	/// (ValueFieldDefinition)
 	/// </summary>
-	public ushort TemplateId;
+	private ushort templateId;
+	public ushort TemplateId { readonly get => templateId; set => templateId = value; }
 	/// <summary>
 	/// 
 	/// (ValueFieldDefinition)
 	/// </summary>
-	public ushort SchemaId;
+	private ushort schemaId;
+	public ushort SchemaId { readonly get => schemaId; set => schemaId = value; }
 	/// <summary>
 	/// 
 	/// (ValueFieldDefinition)
 	/// </summary>
-	public ushort Version;
+	private ushort version;
+	public ushort Version { readonly get => version; set => version = value; }
 	/// <summary>Returns a string representation of this struct for debugging.</summary>
 	public readonly override string ToString() => $"MessageHeader {{ BlockLength={BlockLength}, TemplateId={TemplateId}, SchemaId={SchemaId}, Version={Version} }}";
 }

--- a/tests/SbeCodeGenerator.Tests/TypesCodeGeneratorTests.cs
+++ b/tests/SbeCodeGenerator.Tests/TypesCodeGeneratorTests.cs
@@ -740,7 +740,9 @@ namespace SbeCodeGenerator.Tests
             var engineResult = results.FirstOrDefault(r => r.name.Contains("Engine"));
             Assert.NotEqual(default, engineResult);
             // Should embed Booster as a field
-            Assert.Contains("public Booster Booster;", engineResult.content);
+            Assert.Contains("private Booster booster;", engineResult.content);
+            Assert.Contains("[System.Diagnostics.CodeAnalysis.UnscopedRef]", engineResult.content);
+            Assert.Contains("public ref Booster Booster => ref booster;", engineResult.content);
             // Engine should be blittable (all fields fixed-size)
             Assert.Contains("[StructLayout(LayoutKind.Sequential, Pack = 1)]", engineResult.content);
             // MESSAGE_SIZE should include Booster size (1 char + 2 uint16 = 3) + capacity(2) + numCylinders(1) = 6
@@ -802,7 +804,9 @@ namespace SbeCodeGenerator.Tests
             // Outer composite should embed Inner as a field
             var outerResult = results.FirstOrDefault(r => r.name.Contains("Outer") && !r.name.Contains("Inner"));
             Assert.NotEqual(default, outerResult);
-            Assert.Contains("public Inner Inner;", outerResult.content);
+            Assert.Contains("private Inner inner;", outerResult.content);
+            Assert.Contains("[System.Diagnostics.CodeAnalysis.UnscopedRef]", outerResult.content);
+            Assert.Contains("public ref Inner Inner => ref inner;", outerResult.content);
             // Outer size: uint32(4) + Inner(3) = 7
             Assert.Contains("MESSAGE_SIZE = 7;", outerResult.content);
         }

--- a/tests/SbeCodeGenerator.Tests/TypesCodeGeneratorTests.cs
+++ b/tests/SbeCodeGenerator.Tests/TypesCodeGeneratorTests.cs
@@ -1049,5 +1049,116 @@ namespace SbeCodeGenerator.Tests
             // Assert — no ToDecimal file generated for non-decimal composites
             Assert.DoesNotContain(results, r => r.name.Contains("ToDecimal"));
         }
+
+        [Fact]
+        public void Generate_WithTimestampNanosComposite_ProducesToDateTimeMethods()
+        {
+            // Arrange
+            var generator = new TypesCodeGenerator();
+            var context = new SchemaContext("test-schema");
+            var schema = SchemaReader.Parse(@"
+                <sbe:messageSchema xmlns:sbe='http://fixprotocol.io/2016/sbe'>
+                    <types>
+                        <enum name='TimeUnit' encodingType='uint8'>
+                            <validValue name='nanosecond'>0</validValue>
+                            <validValue name='second'>5</validValue>
+                        </enum>
+                        <composite name='UTCTimestampNanos' description='Nanosecond timestamp'>
+                            <type name='time' primitiveType='uint64' presence='optional'/>
+                            <type name='unit' primitiveType='uint8' presence='constant' valueRef='TimeUnit.nanosecond'>0</type>
+                        </composite>
+                    </types>
+                </sbe:messageSchema>");
+
+            // Act
+            var results = generator.Generate("TestNamespace", schema, context, default(SourceProductionContext)).ToList();
+            var toDateTimeResult = results.First(r => r.name.Contains("ToDateTime"));
+
+            // Assert — optional time field returns DateTime? and DateTimeOffset?
+            Assert.Contains("public partial struct UTCTimestampNanos", toDateTimeResult.content);
+            Assert.Contains("public readonly System.DateTime? ToDateTime()", toDateTimeResult.content);
+            Assert.Contains("AddTicks((long)(Time.Value / 100))", toDateTimeResult.content);
+            Assert.Contains("public readonly System.DateTimeOffset? ToDateTimeOffset()", toDateTimeResult.content);
+        }
+
+        [Fact]
+        public void Generate_WithTimestampSecondsComposite_ProducesToDateTimeMethods()
+        {
+            // Arrange
+            var generator = new TypesCodeGenerator();
+            var context = new SchemaContext("test-schema");
+            var schema = SchemaReader.Parse(@"
+                <sbe:messageSchema xmlns:sbe='http://fixprotocol.io/2016/sbe'>
+                    <types>
+                        <enum name='TimeUnit' encodingType='uint8'>
+                            <validValue name='second'>5</validValue>
+                        </enum>
+                        <composite name='UTCTimestampSeconds' description='Second timestamp'>
+                            <type name='time' primitiveType='uint64'/>
+                            <type name='unit' primitiveType='uint8' presence='constant' valueRef='TimeUnit.second'>5</type>
+                        </composite>
+                    </types>
+                </sbe:messageSchema>");
+
+            // Act
+            var results = generator.Generate("TestNamespace", schema, context, default(SourceProductionContext)).ToList();
+            var toDateTimeResult = results.First(r => r.name.Contains("ToDateTime"));
+
+            // Assert — non-optional time returns DateTime (not nullable)
+            Assert.Contains("public readonly System.DateTime ToDateTime()", toDateTimeResult.content);
+            Assert.Contains("FromUnixTimeSeconds((long)Time)", toDateTimeResult.content);
+            Assert.Contains("public readonly System.DateTimeOffset ToDateTimeOffset()", toDateTimeResult.content);
+            Assert.DoesNotContain("DateTime?", toDateTimeResult.content);
+        }
+
+        [Fact]
+        public void Generate_WithTimestampMillisComposite_ProducesToDateTimeMethods()
+        {
+            // Arrange
+            var generator = new TypesCodeGenerator();
+            var context = new SchemaContext("test-schema");
+            var schema = SchemaReader.Parse(@"
+                <sbe:messageSchema xmlns:sbe='http://fixprotocol.io/2016/sbe'>
+                    <types>
+                        <enum name='TimeUnit' encodingType='uint8'>
+                            <validValue name='millisecond'>3</validValue>
+                        </enum>
+                        <composite name='UTCTimestampMillis' description='Millisecond timestamp'>
+                            <type name='time' primitiveType='uint64'/>
+                            <type name='unit' primitiveType='uint8' presence='constant' valueRef='TimeUnit.millisecond'>3</type>
+                        </composite>
+                    </types>
+                </sbe:messageSchema>");
+
+            // Act
+            var results = generator.Generate("TestNamespace", schema, context, default(SourceProductionContext)).ToList();
+            var toDateTimeResult = results.First(r => r.name.Contains("ToDateTime"));
+
+            // Assert
+            Assert.Contains("FromUnixTimeMilliseconds((long)Time)", toDateTimeResult.content);
+        }
+
+        [Fact]
+        public void Generate_WithNonTimestampComposite_DoesNotProduceToDateTime()
+        {
+            // Arrange
+            var generator = new TypesCodeGenerator();
+            var context = new SchemaContext("test-schema");
+            var schema = SchemaReader.Parse(@"
+                <sbe:messageSchema xmlns:sbe='http://fixprotocol.io/2016/sbe'>
+                    <types>
+                        <composite name='Engine' description='Engine data'>
+                            <type name='capacity' primitiveType='uint16'/>
+                            <type name='numCylinders' primitiveType='uint8'/>
+                        </composite>
+                    </types>
+                </sbe:messageSchema>");
+
+            // Act
+            var results = generator.Generate("TestNamespace", schema, context, default(SourceProductionContext)).ToList();
+
+            // Assert
+            Assert.DoesNotContain(results, r => r.name.Contains("ToDateTime"));
+        }
     }
 }

--- a/tests/SbeCodeGenerator.Tests/TypesCodeGeneratorTests.cs
+++ b/tests/SbeCodeGenerator.Tests/TypesCodeGeneratorTests.cs
@@ -1160,5 +1160,108 @@ namespace SbeCodeGenerator.Tests
             // Assert
             Assert.DoesNotContain(results, r => r.name.Contains("ToDateTime"));
         }
+
+        [Fact]
+        public void Generate_WithLocalMktDateType_ProducesToDateOnlyMethod()
+        {
+            // Arrange
+            var generator = new TypesCodeGenerator();
+            var context = new SchemaContext("test-schema");
+            var schema = SchemaReader.Parse(@"
+                <sbe:messageSchema xmlns:sbe='http://fixprotocol.io/2016/sbe'>
+                    <types>
+                        <type name='LocalMktDate32' primitiveType='int32' semanticType='LocalMktDate' description='Days since epoch'/>
+                    </types>
+                </sbe:messageSchema>");
+
+            // Act
+            var results = generator.Generate("TestNamespace", schema, context, default(SourceProductionContext)).ToList();
+            var toDateOnlyResult = results.First(r => r.name.Contains("ToDateOnly"));
+
+            // Assert — non-optional returns DateOnly
+            Assert.Contains("public partial struct LocalMktDate32", toDateOnlyResult.content);
+            Assert.Contains("public readonly System.DateOnly ToDateOnly()", toDateOnlyResult.content);
+            Assert.Contains("AddDays(Value)", toDateOnlyResult.content);
+            Assert.DoesNotContain("DateOnly?", toDateOnlyResult.content);
+        }
+
+        [Fact]
+        public void Generate_WithOptionalLocalMktDateType_ProducesNullableToDateOnlyMethod()
+        {
+            // Arrange
+            var generator = new TypesCodeGenerator();
+            var context = new SchemaContext("test-schema");
+            var schema = SchemaReader.Parse(@"
+                <sbe:messageSchema xmlns:sbe='http://fixprotocol.io/2016/sbe'>
+                    <types>
+                        <type name='LocalMktDate32Optional' primitiveType='int32' presence='optional' nullValue='0' semanticType='LocalMktDate' description='Optional days since epoch'/>
+                    </types>
+                </sbe:messageSchema>");
+
+            // Act
+            var results = generator.Generate("TestNamespace", schema, context, default(SourceProductionContext)).ToList();
+            var toDateOnlyResult = results.First(r => r.name.Contains("ToDateOnly"));
+
+            // Assert — optional returns DateOnly?
+            Assert.Contains("public partial struct LocalMktDate32Optional", toDateOnlyResult.content);
+            Assert.Contains("public readonly System.DateOnly? ToDateOnly()", toDateOnlyResult.content);
+            Assert.Contains("Value.HasValue", toDateOnlyResult.content);
+        }
+
+        [Fact]
+        public void Generate_WithMonthYearComposite_ProducesToDateOnlyMethod()
+        {
+            // Arrange
+            var generator = new TypesCodeGenerator();
+            var context = new SchemaContext("test-schema");
+            var schema = SchemaReader.Parse(@"
+                <sbe:messageSchema xmlns:sbe='http://fixprotocol.io/2016/sbe'>
+                    <types>
+                        <composite name='MaturityMonthYear' semanticType='MonthYear' description='Month-Year with optional day'>
+                            <type name='year' primitiveType='uint16' presence='optional'/>
+                            <type name='month' primitiveType='uint8' presence='optional'/>
+                            <type name='day' primitiveType='uint8' presence='optional'/>
+                            <type name='week' primitiveType='uint8' presence='optional'/>
+                        </composite>
+                    </types>
+                </sbe:messageSchema>");
+
+            // Act
+            var results = generator.Generate("TestNamespace", schema, context, default(SourceProductionContext)).ToList();
+            var toDateOnlyResult = results.First(r => r.name.Contains("ToDateOnly"));
+
+            // Assert
+            Assert.Contains("public partial struct MaturityMonthYear", toDateOnlyResult.content);
+            Assert.Contains("public readonly System.DateOnly? ToDateOnly()", toDateOnlyResult.content);
+            Assert.Contains("Day ?? 1", toDateOnlyResult.content);
+        }
+
+        [Fact]
+        public void Generate_WithMonthYearNoDayComposite_DefaultsDay()
+        {
+            // Arrange
+            var generator = new TypesCodeGenerator();
+            var context = new SchemaContext("test-schema");
+            var schema = SchemaReader.Parse(@"
+                <sbe:messageSchema xmlns:sbe='http://fixprotocol.io/2016/sbe'>
+                    <types>
+                        <composite name='SimpleMonthYear' semanticType='MonthYear' description='Just month and year'>
+                            <type name='year' primitiveType='uint16'/>
+                            <type name='month' primitiveType='uint8'/>
+                        </composite>
+                    </types>
+                </sbe:messageSchema>");
+
+            // Act
+            var results = generator.Generate("TestNamespace", schema, context, default(SourceProductionContext)).ToList();
+            var toDateOnlyResult = results.First(r => r.name.Contains("ToDateOnly"));
+
+            // Assert — no day field, defaults to 1
+            Assert.Contains("public readonly System.DateOnly? ToDateOnly()", toDateOnlyResult.content);
+            Assert.DoesNotContain("Day ??", toDateOnlyResult.content);
+            // Non-optional year/month are wrapped in nullable for the pattern match
+            Assert.Contains("(ushort?)Year is { } y", toDateOnlyResult.content);
+            Assert.Contains("(byte?)Month is { } m", toDateOnlyResult.content);
+        }
     }
 }

--- a/tests/SbeCodeGenerator.Tests/TypesCodeGeneratorTests.cs
+++ b/tests/SbeCodeGenerator.Tests/TypesCodeGeneratorTests.cs
@@ -973,5 +973,81 @@ namespace SbeCodeGenerator.Tests
             Assert.Contains("public readonly override string ToString()", decimalResult.content);
             Assert.Contains("Decimal {{ Mantissa={Mantissa} }}", decimalResult.content);
         }
+
+        [Fact]
+        public void Generate_WithDecimalComposite_ProducesToDecimalMethod()
+        {
+            // Arrange
+            var generator = new TypesCodeGenerator();
+            var context = new SchemaContext("test-schema");
+            var schema = SchemaReader.Parse(@"
+                <sbe:messageSchema xmlns:sbe='http://fixprotocol.io/2016/sbe'>
+                    <types>
+                        <composite name='Price' description='Price with 4 decimal places'>
+                            <type name='mantissa' primitiveType='int64'/>
+                            <type name='exponent' primitiveType='int8' presence='constant'>-4</type>
+                        </composite>
+                    </types>
+                </sbe:messageSchema>");
+
+            // Act
+            var results = generator.Generate("TestNamespace", schema, context, default(SourceProductionContext)).ToList();
+            var toDecimalResult = results.First(r => r.name.Contains("ToDecimal"));
+
+            // Assert — non-optional mantissa returns decimal (not decimal?)
+            Assert.Contains("public partial struct Price", toDecimalResult.content);
+            Assert.Contains("public readonly decimal ToDecimal() => Mantissa * 1e-4m;", toDecimalResult.content);
+            Assert.DoesNotContain("decimal?", toDecimalResult.content);
+        }
+
+        [Fact]
+        public void Generate_WithOptionalDecimalComposite_ProducesNullableToDecimalMethod()
+        {
+            // Arrange
+            var generator = new TypesCodeGenerator();
+            var context = new SchemaContext("test-schema");
+            var schema = SchemaReader.Parse(@"
+                <sbe:messageSchema xmlns:sbe='http://fixprotocol.io/2016/sbe'>
+                    <types>
+                        <composite name='PriceOptional' description='Optional price'>
+                            <type name='mantissa' primitiveType='int64' presence='optional'/>
+                            <type name='exponent' primitiveType='int8' presence='constant'>-8</type>
+                        </composite>
+                    </types>
+                </sbe:messageSchema>");
+
+            // Act
+            var results = generator.Generate("TestNamespace", schema, context, default(SourceProductionContext)).ToList();
+            var toDecimalResult = results.First(r => r.name.Contains("ToDecimal"));
+
+            // Assert — optional mantissa returns decimal?
+            Assert.Contains("public partial struct PriceOptional", toDecimalResult.content);
+            Assert.Contains("public readonly decimal? ToDecimal() => Mantissa.HasValue ? Mantissa.Value * 1e-8m : null;", toDecimalResult.content);
+        }
+
+        [Fact]
+        public void Generate_WithNonDecimalComposite_DoesNotProduceToDecimal()
+        {
+            // Arrange
+            var generator = new TypesCodeGenerator();
+            var context = new SchemaContext("test-schema");
+            var schema = SchemaReader.Parse(@"
+                <sbe:messageSchema xmlns:sbe='http://fixprotocol.io/2016/sbe'>
+                    <types>
+                        <composite name='messageHeader' description='Message header'>
+                            <type name='blockLength' primitiveType='uint16'/>
+                            <type name='templateId' primitiveType='uint16'/>
+                            <type name='schemaId' primitiveType='uint16'/>
+                            <type name='version' primitiveType='uint16'/>
+                        </composite>
+                    </types>
+                </sbe:messageSchema>");
+
+            // Act
+            var results = generator.Generate("TestNamespace", schema, context, default(SourceProductionContext)).ToList();
+
+            // Assert — no ToDecimal file generated for non-decimal composites
+            Assert.DoesNotContain(results, r => r.name.Contains("ToDecimal"));
+        }
     }
 }


### PR DESCRIPTION
## v1.1.0 — Consumer Improvements

### Added
- **`ToDecimal()`** on decimal composites (mantissa + constant exponent) (#131)
- **`ToDateTime()` / `ToDateTimeOffset()`** on timestamp composites (#132)
- **`ToDateOnly()`** on LocalMktDate types and MonthYear composites (#133)
- **`AsSpan()` / `Equals(ReadOnlySpan<byte>)`** on InlineArray char types (#134)
- **Named null sentinel constants** (`{Field}NullValue`) (#136)

### Changed
- **Field visibility**: private backing + `readonly get` / `set` properties (#137)
- **`readonly` methods**: TryEncode, Encode, ToString, AsSpan, Equals (#135)
- **`readonly struct`** for ConstantTypeDefinition (#135)

### Tests
306 total (187 unit + 119 integration), 18 new tests added.

Closes #131, #132, #133, #134, #135, #136, #137