### PR TITLE
fix: resolve CS8656 regression with composite struct fields (#139)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2025-07-25
+
+### Fixed
+- **CS8656 regression with composite struct fields** (#139): Composite-type fields (e.g., `Price`, `Engine`, `Instrument`) now use value-returning `readonly get; set;` properties instead of `ref`-returning properties. This fixes 337 CS8656 compiler errors when `readonly` methods (like `ToString`) accessed mutable ref-returning properties. Sub-field mutation (`msg.Engine.Capacity = 5`) must now use whole-struct assignment (`msg.Engine = new Engine { Capacity = 5 }`).
+
 ## [1.1.0] - 2026-04-15
 
 ### Added
@@ -15,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Named null sentinel constants** (#136): Optional fields now expose a named `{FieldName}NullValue` constant (e.g., `MantissaNullValue`, `TimeNullValue`) instead of inline magic numbers.
 
 ### Changed
-- **Field visibility standardization** (#137): All struct fields now use `private` backing fields with `public` property accessors (`readonly get` + `set`). Composite/InlineArray fields use `ref`-returning properties with `[UnscopedRef]`.
+- **Field visibility standardization** (#137): All struct fields now use `private` backing fields with `public` property accessors (`readonly get` + `set`).
 - **`readonly` methods on generated structs** (#135): `TryEncode`, `TryEncodeWithWriter`, `Encode`, `AsSpan`, `Equals`, and `ToString` are now `readonly` instance methods to prevent defensive copies. `ConstantTypeDefinition` emits `readonly struct`.
 
 ## [1.0.2] - 2026-04-10

--- a/src/SbeCodeGenerator/EndianFieldHelper.cs
+++ b/src/SbeCodeGenerator/EndianFieldHelper.cs
@@ -58,9 +58,10 @@ namespace SbeSourceGenerator
 
             if (isStructType)
             {
-                sb.AppendTabs(tabs).AppendLine("[System.Diagnostics.CodeAnalysis.UnscopedRef]");
-                sb.AppendTabs(tabs).Append("public ref ").Append(declaredType).Append(" ").Append(name)
-                    .Append(" => ref ").Append(fieldName).AppendLine(";");
+                sb.AppendTabs(tabs).Append("public ").Append(declaredType).Append(" ").Append(name)
+                    .Append(" { readonly get => ").Append(fieldName)
+                    .Append("; set => ").Append(fieldName).Append(" = value; }")
+                    .AppendLine();
                 return;
             }
 

--- a/src/SbeCodeGenerator/Generators/Fields/CompositeRefFieldDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Fields/CompositeRefFieldDefinition.cs
@@ -13,9 +13,10 @@ namespace SbeSourceGenerator
             string fieldName = Name.FirstCharToLower();
             sb.AppendSummary(Description, tabs, nameof(CompositeRefFieldDefinition));
             sb.AppendTabs(tabs).Append("private ").Append(TypeName).Append(" ").Append(fieldName).AppendLine(";");
-            sb.AppendTabs(tabs).AppendLine("[System.Diagnostics.CodeAnalysis.UnscopedRef]");
-            sb.AppendTabs(tabs).Append("public ref ").Append(TypeName).Append(" ").Append(Name)
-                .Append(" => ref ").Append(fieldName).AppendLine(";");
+            sb.AppendTabs(tabs).Append("public ").Append(TypeName).Append(" ").Append(Name)
+                .Append(" { readonly get => ").Append(fieldName)
+                .Append("; set => ").Append(fieldName).Append(" = value; }")
+                .AppendLine();
         }
     }
 }

--- a/src/SbeCodeGenerator/SbeSourceGenerator.csproj
+++ b/src/SbeCodeGenerator/SbeSourceGenerator.csproj
@@ -11,7 +11,7 @@
 		<IncludeBuildOutput>false</IncludeBuildOutput>
 		<PackageId>SbeSourceGenerator</PackageId>
 		<Title>SBE Source Generator</Title>
-		<Version>1.1.0</Version>
+		<Version>1.1.1</Version>
 		<Authors>Pedro Sakuma</Authors>
 		<Company>Pedro Sakuma</Company>
 		<Product>SBE Source Generator</Product>

--- a/tests/SbeCodeGenerator.IntegrationTests/CarExampleIntegrationTests.cs
+++ b/tests/SbeCodeGenerator.IntegrationTests/CarExampleIntegrationTests.cs
@@ -57,8 +57,7 @@ namespace SbeCodeGenerator.IntegrationTests
             car.Code = Model.B;
             car.Extras = OptionalExtras.SunRoof | OptionalExtras.CruiseControl;
 
-            car.Engine.Capacity = 2000;
-            car.Engine.NumCylinders = 4;
+            car.Engine = new Engine { Capacity = 2000, NumCylinders = 4 };
 
             Assert.Equal(1234567890UL, car.SerialNumber);
             Assert.Equal((ushort)2024, car.ModelYear.Value);
@@ -83,7 +82,7 @@ namespace SbeCodeGenerator.IntegrationTests
             Span<byte> buffer = stackalloc byte[CarData.MESSAGE_SIZE];
             ref CarData car = ref MemoryMarshal.AsRef<CarData>(buffer);
             car.SerialNumber = 42;
-            car.Engine.Capacity = 1600;
+            car.Engine = new Engine { Capacity = 1600 };
 
             var success = CarData.TryParse(buffer, out var parsed);
 
@@ -206,7 +205,7 @@ namespace SbeCodeGenerator.IntegrationTests
             // Write Car fixed fields
             ref CarData car = ref MemoryMarshal.AsRef<CarData>(span);
             car.SerialNumber = 42;
-            car.Engine.Capacity = 2000;
+            car.Engine = new Engine { Capacity = 2000 };
             offset += CarData.MESSAGE_SIZE;
 
             // fuelFigures group: 1 entry

--- a/tests/SbeCodeGenerator.IntegrationTests/EdgeCaseIntegrationTests.cs
+++ b/tests/SbeCodeGenerator.IntegrationTests/EdgeCaseIntegrationTests.cs
@@ -85,8 +85,9 @@ namespace SbeCodeGenerator.IntegrationTests
             inst.InstrumentId = 12345;
 
             // Write ISIN code into the Isin field
-            var isinBytes = Encoding.Latin1.GetBytes("US0378331005");
-            isinBytes.CopyTo(MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref inst.Isin, 1)).Slice(0, 12));
+            IsinCode isin = default;
+            Encoding.Latin1.GetBytes("US0378331005").CopyTo(MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref isin, 1)).Slice(0, 12));
+            inst.Isin = isin;
 
             Assert.True(Instrument.TryParse(buffer, out var parsed, out _));
             Assert.Equal(12345L, parsed.InstrumentId);
@@ -145,8 +146,8 @@ namespace SbeCodeGenerator.IntegrationTests
             ref var trade = ref MemoryMarshal.AsRef<TradeData>(buffer);
 
             trade.TradeId = 999L;
-            trade.Instrument.InstrumentId = 42L;
-            trade.Price.Mantissa = 15000000L;
+            trade.Instrument = new Instrument { InstrumentId = 42L };
+            trade.Price = new DecimalEncoding { Mantissa = 15000000L };
             trade.Quantity = 100L;
             trade.Status = StatusCode.Filled;
             trade.Flags = TradingFlags.Regular | TradingFlags.DarkPool;

--- a/tests/SbeCodeGenerator.Tests/MessagesCodeGeneratorTests.cs
+++ b/tests/SbeCodeGenerator.Tests/MessagesCodeGeneratorTests.cs
@@ -726,8 +726,7 @@ namespace SbeCodeGenerator.Tests
 
             // Assert - should be a regular field (not optional), composites handle their own null semantics
             Assert.Contains("private PriceOptional price;", msgResult.content);
-            Assert.Contains("[System.Diagnostics.CodeAnalysis.UnscopedRef]", msgResult.content);
-            Assert.Contains("public ref PriceOptional Price => ref price;", msgResult.content);
+            Assert.Contains("public PriceOptional Price { readonly get => price; set => price = value; }", msgResult.content);
             Assert.DoesNotContain("PriceOptional?", msgResult.content); // No nullable
             Assert.DoesNotContain("== default", msgResult.content); // No default comparison
         }

--- a/tests/SbeCodeGenerator.Tests/TypesCodeGeneratorTests.cs
+++ b/tests/SbeCodeGenerator.Tests/TypesCodeGeneratorTests.cs
@@ -741,8 +741,7 @@ namespace SbeCodeGenerator.Tests
             Assert.NotEqual(default, engineResult);
             // Should embed Booster as a field
             Assert.Contains("private Booster booster;", engineResult.content);
-            Assert.Contains("[System.Diagnostics.CodeAnalysis.UnscopedRef]", engineResult.content);
-            Assert.Contains("public ref Booster Booster => ref booster;", engineResult.content);
+            Assert.Contains("public Booster Booster { readonly get => booster; set => booster = value; }", engineResult.content);
             // Engine should be blittable (all fields fixed-size)
             Assert.Contains("[StructLayout(LayoutKind.Sequential, Pack = 1)]", engineResult.content);
             // MESSAGE_SIZE should include Booster size (1 char + 2 uint16 = 3) + capacity(2) + numCylinders(1) = 6
@@ -805,8 +804,7 @@ namespace SbeCodeGenerator.Tests
             var outerResult = results.FirstOrDefault(r => r.name.Contains("Outer") && !r.name.Contains("Inner"));
             Assert.NotEqual(default, outerResult);
             Assert.Contains("private Inner inner;", outerResult.content);
-            Assert.Contains("[System.Diagnostics.CodeAnalysis.UnscopedRef]", outerResult.content);
-            Assert.Contains("public ref Inner Inner => ref inner;", outerResult.content);
+            Assert.Contains("public Inner Inner { readonly get => inner; set => inner = value; }", outerResult.content);
             // Outer size: uint32(4) + Inner(3) = 7
             Assert.Contains("MESSAGE_SIZE = 7;", outerResult.content);
         }


### PR DESCRIPTION
## Summary

Fixes #139 — 337 CS8656 compiler errors introduced in v1.1.0.

## Root Cause

Composite-type fields (e.g., `Price`, `Engine`, `Instrument`) used `ref`-returning properties (`public ref T Name => ref field;`). These are inherently non-readonly — when `readonly` methods like `ToString()` access them, the compiler emits CS8656.

## Fix

Changed composite-type field properties from `ref`-returning to value-returning (`readonly get; set;`):

```csharp
// Before (causes CS8656 in readonly methods)
[UnscopedRef] public ref Price Price => ref price;

// After
public Price Price { readonly get => price; set => price = value; }
```

## Breaking Change

Sub-field mutation through a parent is no longer possible:
```csharp
// Before (no longer compiles — CS1612)
msg.Engine.Capacity = 5;

// After (whole-struct assignment)
msg.Engine = new Engine { Capacity = 5 };
```

## Testing

- ✅ 187 unit tests pass
- ✅ 119 integration tests pass
- ✅ Zero CS8656 warnings in build
- Version bumped to 1.1.1