### PR TITLE
fix: remaining CS8656 on OptionalType Value + TreatWarningsAsErrors (#139)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2] - 2026-04-15
+
+### Fixed
+- **Remaining CS8656 on optional type Value property** (#139): Added `readonly` modifier to `Value` getter in `OptionalTypeDefinition`, fixing 4 remaining CS8656 errors on `LocalMktDateOptional` and `LocalMktDate32Optional`.
+
+### Changed
+- **Integration tests now treat warnings as errors**: Added `TreatWarningsAsErrors` to the integration test project to catch generated code warnings (like CS8656) as build failures, preventing future regressions.
+
 ## [1.1.1] - 2025-07-25
 
 ### Fixed

--- a/src/SbeCodeGenerator/Generators/Types/OptionalTypeDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Types/OptionalTypeDefinition.cs
@@ -17,7 +17,7 @@ namespace SbeSourceGenerator
             sb.AppendLine("{", tabs++);
             NullableValueFieldDefinition.AppendNullConstant(sb, tabs, PrimitiveType, "ValueNullValue", nullValue);
             sb.AppendTabs(tabs).Append("private ").Append(PrimitiveType).AppendLine(" value;");
-            sb.AppendTabs(tabs).Append("public ").Append(PrimitiveType).Append("? Value");
+            sb.AppendTabs(tabs).Append("public readonly ").Append(PrimitiveType).Append("? Value");
             NullableValueFieldDefinition.AppendNullCheck(sb, PrimitiveType, "value", nullValue, "ValueNullValue");
             sb.AppendLine("}", --tabs);
             sb.AppendLine("#pragma warning restore CS0649", tabs);

--- a/src/SbeCodeGenerator/SbeSourceGenerator.csproj
+++ b/src/SbeCodeGenerator/SbeSourceGenerator.csproj
@@ -11,7 +11,7 @@
 		<IncludeBuildOutput>false</IncludeBuildOutput>
 		<PackageId>SbeSourceGenerator</PackageId>
 		<Title>SBE Source Generator</Title>
-		<Version>1.1.1</Version>
+		<Version>1.1.2</Version>
 		<Authors>Pedro Sakuma</Authors>
 		<Company>Pedro Sakuma</Company>
 		<Product>SBE Source Generator</Product>

--- a/tests/SbeCodeGenerator.IntegrationTests/SbeCodeGenerator.IntegrationTests.csproj
+++ b/tests/SbeCodeGenerator.IntegrationTests/SbeCodeGenerator.IntegrationTests.csproj
@@ -8,6 +8,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>CS0436</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Fixes the remaining 4 CS8656 errors reported in #139.

## Changes

### Fix: `readonly` on OptionalTypeDefinition Value property
The `Value` getter in `OptionalTypeDefinition` was missing the `readonly` modifier, causing CS8656 when `readonly ToDateOnly()` called it on `LocalMktDateOptional` and `LocalMktDate32Optional`.

### Prevention: `TreatWarningsAsErrors` on integration tests
Added `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>` to the integration test project. This ensures any future generated code warnings (like CS8656) will fail the build, catching regressions before they reach consumers.

## Testing
- ✅ 187 unit tests pass
- ✅ 119 integration tests pass (now with TreatWarningsAsErrors)
- Version bumped to 1.1.2