### PR TITLE
fix: restore widest-version base struct alias (#149)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2026-04-25
+
+### Fixed
+- **Unsuffixed `{Message}Data` alias collapsed to baseline V0 instead of widest version** (#149): The `effectiveVersion` widening logic introduced in v1.1.4 (#143) was inadvertently dropped while wiring the per-version blockLength compute for the new `{Msg}VersionMap` (#146). Restored: the unsuffixed canonical struct again includes every field added across the schema's version history (matches the natural reader expectation and v1.1.4 behavior). The per-version `{Msg}V{N}Data` aliases and the `{Msg}VersionMap` entries continue to use each version's own blockLength.
+
 ## [1.2.0] - 2026-04-25
 
 ### Added

--- a/src/SbeCodeGenerator/Generators/MessagesCodeGenerator.cs
+++ b/src/SbeCodeGenerator/Generators/MessagesCodeGenerator.cs
@@ -31,7 +31,17 @@ namespace SbeSourceGenerator.Generators
                 foreach (var version in versions)
                 {
                     var versionNamespace = GetVersionNamespace(baseNamespace, ns, version);
-                    var fieldsForVersion = GetFieldsForVersion(messageDto.Fields, version, sourceContext, context);
+
+                    // For the canonical/unsuffixed struct (version 0 file), include all fields up to the
+                    // schema version so the unsuffixed alias is the widest struct, matching #143 and the
+                    // natural reader expectation ("give me everything the schema can tell me about this
+                    // message"). The per-version blockLength used by the VersionMap is computed below
+                    // using each version's *own* field set, independently.
+                    int effectiveVersion = version;
+                    if (version == 0 && versions.Count > 1)
+                        effectiveVersion = schemaVersion >= 0 ? schemaVersion : versions[versions.Count - 1];
+
+                    var fieldsForVersion = GetFieldsForVersion(messageDto.Fields, effectiveVersion, sourceContext, context);
 
                     string headerTypeName = "MessageHeader";
                     if (context.GeneratedTypeNames.TryGetValue(context.HeaderType, out var resolvedHeaderName))
@@ -42,17 +52,17 @@ namespace SbeSourceGenerator.Generators
                         ns,
                         generatedMessageName,
                         messageDto.Id,
-                        $"{messageDto.Description} (Version {version})",
+                        $"{messageDto.Description} (Version {effectiveVersion})",
                         messageDto.SemanticType,
                         messageDto.Deprecated,
                         fieldsForVersion,
                         BuildConstants(messageDto.Constants, context),
                         BuildGroups(messageDto.Groups, versionNamespace, context, sourceContext),
-                        GetDataForVersion(messageDto.Data, version, context),
+                        GetDataForVersion(messageDto.Data, effectiveVersion, context),
                         messageDto.BlockLength,
                         context.EndianConversion,
                         schema.Id,
-                        version.ToString(),
+                        effectiveVersion.ToString(),
                         headerTypeName
                     );
                     int estimatedCapacity = 2048 + fieldsForVersion.Count * 256
@@ -66,7 +76,7 @@ namespace SbeSourceGenerator.Generators
                     yield return (fileName, sb.ToString());
 
                     // Compute this version's wire BLOCK_LENGTH using the version's *own* field set
-                    // (sinceVersion <= version), NOT the V0 effectiveVersion override. This is what
+                    // (sinceVersion <= version), NOT the widened effectiveVersion above. This is what
                     // a producer at that version would have written on the wire — the basis for the version map.
                     int blockLength;
                     if (!string.IsNullOrEmpty(messageDto.BlockLength)

--- a/src/SbeCodeGenerator/SbeSourceGenerator.csproj
+++ b/src/SbeCodeGenerator/SbeSourceGenerator.csproj
@@ -11,7 +11,7 @@
 		<IncludeBuildOutput>false</IncludeBuildOutput>
 		<PackageId>SbeSourceGenerator</PackageId>
 		<Title>SBE Source Generator</Title>
-		<Version>1.2.0</Version>
+		<Version>1.2.1</Version>
 		<Authors>Pedro Sakuma</Authors>
 		<Company>Pedro Sakuma</Company>
 		<Product>SBE Source Generator</Product>

--- a/tests/SbeCodeGenerator.IntegrationTests/VersioningIntegrationTests.cs
+++ b/tests/SbeCodeGenerator.IntegrationTests/VersioningIntegrationTests.cs
@@ -39,20 +39,27 @@ namespace SbeCodeGenerator.IntegrationTests
         }
 
         [Fact]
-        public void V0Type_HasOnlyBaseFields()
+        public void V0Type_IsWidestStruct_IncludesAllSinceVersionFields()
         {
-            // V0 should have only orderId and price (16 bytes)
-            Assert.Equal(16, V0.EvolvingOrderData.MESSAGE_SIZE);
-            
-            // Verify we can create and use V0 type
+            // Issue #143/#149: the unsuffixed (V0-namespace) struct is the widest variant —
+            // it includes every field added across the schema's version history (orderId + price
+            // + quantity + side + slack = 25 bytes), so consumers can read everything a current
+            // producer would have written. The narrow V0 layout is still available via the
+            // {Msg}VersionMap + V1/V2 namespaces.
+            Assert.Equal(25, V0.EvolvingOrderData.MESSAGE_SIZE);
+
             Span<byte> buffer = stackalloc byte[V0.EvolvingOrderData.MESSAGE_SIZE];
             ref V0.EvolvingOrderData message = ref MemoryMarshal.AsRef<V0.EvolvingOrderData>(buffer);
-            
+
             message.OrderId = 100;
             message.Price = 9950;
-            
+            message.Quantity = 50;
+            message.Side = 1;
+
             Assert.Equal(100, message.OrderId.Value);
             Assert.Equal(9950, message.Price.Value);
+            Assert.Equal(50, message.Quantity);
+            Assert.Equal(1, message.Side);
         }
 
         [Fact]


### PR DESCRIPTION
Closes #149.

## Regressão
v1.2.0 colapsou o alias canônico `{Message}Data` (namespace V0) para o layout V0 estrito, removendo todos os campos adicionados em versões posteriores. Consumidores como o B3 UMDF que liam campos pós-V0 pelo alias canônico passaram a quebrar com CS1061 (ex.: `SnapshotFullRefresh_Header_30Data.LastSequenceVersion`).

## Causa raiz
Ao implementar #146 (VersionMap), o widening de versão (`effectiveVersion`) introduzido em v1.1.4 (#143) foi removido por engano enquanto eu adicionava o cálculo de blockLength por versão. As duas preocupações são independentes:

- **Struct canônico (V0 ns)** → versão *mais ampla*, contém todos os campos com `sinceVersion ≤ schemaVersion`.
- **Entradas do VersionMap** → blockLength próprio de cada versão (16/24/25 no schema de teste).

## Fix
Restaurado o widening apenas para a geração da struct, mantendo a coleta per-versão de blockLength para o VersionMap.

## Testes
`VersioningIntegrationTests.V0Type_HasOnlyBaseFields` foi renomeado para `V0Type_IsWidestStruct_IncludesAllSinceVersionFields` e invertido para refletir o contrato documentado (V0 = 25 bytes no schema de teste, com orderId+price+quantity+side).

187 + 126 testes verdes.