### PR TITLE
feat: expose Buffer/Block on {Msg}DataReader (#151)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-04-25
+
+### Added
+- **Raw buffer access on `{Message}DataReader`** (#151): The generated zero-copy reader now exposes `Buffer` (full source `ReadOnlySpan<byte>`), `Block` (slice sized to the wire `blockLength`), and `BlockLength` as `readonly` properties. Lets dispatcher-based consumers forward or buffer the original bytes (e.g. snapshot-heal flows) without re-parsing or maintaining a parallel manual switch just to capture the body. The data was already in the reader's private `_buffer` field; this only adds public accessors — no codegen size or runtime cost change.
+
 ## [1.2.1] - 2026-04-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ See the [v1.2.0 entry in CHANGELOG.md](./CHANGELOG.md) for the full list.
 
 ## What's New in v1.0.0
 
-**Zero-copy `MessageDataReader`** — `TryParse` now returns a lightweight ref struct that holds a reference directly into the buffer. Access fields via `reader.Data` (zero-copy `ref readonly`) and process groups via `reader.ReadGroups(...)`.
+**Zero-copy `MessageDataReader`** — `TryParse` returns a lightweight ref struct that holds a reference directly into the buffer. Access fields via `reader.Data` (zero-copy `ref readonly`), process groups via `reader.ReadGroups(...)`, and (since v1.3.0) recover the raw wire bytes via `reader.Buffer` / `reader.Block` for replay/forwarding scenarios — no re-parse needed.
 
 ```csharp
 if (CarData.TryParse(buffer, out var car))

--- a/src/SbeCodeGenerator/Generators/Types/MessageDefinition.cs
+++ b/src/SbeCodeGenerator/Generators/Types/MessageDefinition.cs
@@ -637,6 +637,25 @@ namespace SbeSourceGenerator
             sb.AppendTabs(tabs).Append("/// Gets a readonly reference to the ").Append(Name).AppendLine("Data directly in the buffer (zero-copy).");
             sb.AppendLine("/// </summary>", tabs);
             sb.AppendTabs(tabs).Append("public ref readonly ").Append(Name).Append("Data Data => ref Unsafe.As<byte, ").Append(Name).AppendLine("Data>(ref MemoryMarshal.GetReference(_buffer));");
+            sb.AppendLine("", tabs);
+
+            // Issue #151: expose raw spans so consumers can forward/buffer the original bytes
+            // (e.g. snapshot-heal flows that stash the message for later replay).
+            sb.AppendLine("/// <summary>", tabs);
+            sb.AppendLine("/// The full source buffer this reader was constructed from (block + groups + varData).", tabs);
+            sb.AppendLine("/// Note: the span may extend past the message; use <see cref=\"BytesConsumed\"/> after <c>ReadGroups</c> to slice exactly.", tabs);
+            sb.AppendLine("/// </summary>", tabs);
+            sb.AppendLine("public readonly ReadOnlySpan<byte> Buffer => _buffer;", tabs);
+            sb.AppendLine("", tabs);
+
+            sb.AppendLine("/// <summary>", tabs);
+            sb.AppendLine("/// The fixed-size message block, sized to the wire's blockLength.", tabs);
+            sb.AppendLine("/// </summary>", tabs);
+            sb.AppendLine("public readonly ReadOnlySpan<byte> Block => _buffer.Slice(0, _blockLength);", tabs);
+            sb.AppendLine("", tabs);
+
+            sb.AppendLine("/// <summary>The wire blockLength this reader was constructed with.</summary>", tabs);
+            sb.AppendLine("public readonly int BlockLength => _blockLength;", tabs);
 
             // ReadGroups — only for messages with variable data
             if (HasVariableData)

--- a/src/SbeCodeGenerator/SbeSourceGenerator.csproj
+++ b/src/SbeCodeGenerator/SbeSourceGenerator.csproj
@@ -11,7 +11,7 @@
 		<IncludeBuildOutput>false</IncludeBuildOutput>
 		<PackageId>SbeSourceGenerator</PackageId>
 		<Title>SBE Source Generator</Title>
-		<Version>1.2.1</Version>
+		<Version>1.3.0</Version>
 		<Authors>Pedro Sakuma</Authors>
 		<Company>Pedro Sakuma</Company>
 		<Product>SBE Source Generator</Product>

--- a/tests/SbeCodeGenerator.IntegrationTests/ReaderBufferAccessTests.cs
+++ b/tests/SbeCodeGenerator.IntegrationTests/ReaderBufferAccessTests.cs
@@ -1,0 +1,63 @@
+using System;
+using Xunit;
+
+namespace SbeCodeGenerator.IntegrationTests
+{
+    /// <summary>
+    /// Issue #151: <c>{Msg}DataReader</c> exposes the underlying buffer/block as
+    /// <see cref="ReadOnlySpan{T}"/> properties, so consumers can forward or
+    /// buffer the raw bytes (e.g. snapshot-heal flows) without re-parsing.
+    /// </summary>
+    public class ReaderBufferAccessTests
+    {
+        [Fact]
+        public void Reader_ExposesBlockAndBuffer_ForFixedLayoutMessage()
+        {
+            Span<byte> buffer = stackalloc byte[64];
+            var trade = new Edge.Cases.Test.V0.TradeData
+            {
+                TradeId = 42,
+                Quantity = 100,
+            };
+            Assert.True(trade.TryEncode(buffer, out int bytesWritten));
+
+            Assert.True(Edge.Cases.Test.V0.TradeData.TryParse(buffer, out var reader));
+
+            Assert.Equal(Edge.Cases.Test.V0.TradeData.MESSAGE_SIZE, reader.BlockLength);
+            Assert.Equal(reader.BlockLength, reader.Block.Length);
+
+            // Block is the slice the consumer would memcpy for replay.
+            Assert.True(reader.Block.SequenceEqual(buffer.Slice(0, bytesWritten)));
+
+            // Buffer covers the full source span (may extend past the message).
+            Assert.True(reader.Buffer.Length >= reader.BlockLength);
+            Assert.True(reader.Buffer.Slice(0, reader.BlockLength).SequenceEqual(reader.Block));
+        }
+
+        [Fact]
+        public void Reader_BufferAndBlock_ReflectVariableDataMessage()
+        {
+            Span<byte> buffer = stackalloc byte[512];
+            var orderBook = new Integration.Test.V0.OrderBookData { InstrumentId = 7 };
+            var bids = new Integration.Test.V0.OrderBookData.BidsData[]
+            {
+                new() { Price = 100, Quantity = 5 },
+            };
+            var asks = Array.Empty<Integration.Test.V0.OrderBookData.AsksData>();
+
+            Assert.True(Integration.Test.V0.OrderBookData.TryEncode(orderBook, buffer, bids, asks, out int bytesWritten));
+            Assert.True(Integration.Test.V0.OrderBookData.TryParse(buffer, out var reader));
+
+            // Block length matches the fixed message size, regardless of trailing groups.
+            Assert.Equal(Integration.Test.V0.OrderBookData.MESSAGE_SIZE, reader.BlockLength);
+
+            // Drive ReadGroups so BytesConsumed reflects the wire size, then ensure
+            // the consumer can slice the original buffer to the full message footprint.
+            reader.ReadGroups((in Integration.Test.V0.OrderBookData.BidsData _) => { },
+                              (in Integration.Test.V0.OrderBookData.AsksData _) => { });
+            var wireSlice = reader.Buffer.Slice(0, reader.BytesConsumed);
+            Assert.Equal(bytesWritten, wireSlice.Length);
+            Assert.True(wireSlice.SequenceEqual(buffer.Slice(0, bytesWritten)));
+        }
+    }
+}

--- a/tests/SbeCodeGenerator.Tests/Snapshots/MessagesCodeGenerator.Message.Quote.verified.txt
+++ b/tests/SbeCodeGenerator.Tests/Snapshots/MessagesCodeGenerator.Message.Quote.verified.txt
@@ -168,4 +168,18 @@ public ref struct QuoteDataReader
 	/// Gets a readonly reference to the QuoteData directly in the buffer (zero-copy).
 	/// </summary>
 	public ref readonly QuoteData Data => ref Unsafe.As<byte, QuoteData>(ref MemoryMarshal.GetReference(_buffer));
+	
+	/// <summary>
+	/// The full source buffer this reader was constructed from (block + groups + varData).
+	/// Note: the span may extend past the message; use <see cref="BytesConsumed"/> after <c>ReadGroups</c> to slice exactly.
+	/// </summary>
+	public readonly ReadOnlySpan<byte> Buffer => _buffer;
+	
+	/// <summary>
+	/// The fixed-size message block, sized to the wire's blockLength.
+	/// </summary>
+	public readonly ReadOnlySpan<byte> Block => _buffer.Slice(0, _blockLength);
+	
+	/// <summary>The wire blockLength this reader was constructed with.</summary>
+	public readonly int BlockLength => _blockLength;
 }

--- a/tests/SbeCodeGenerator.Tests/Snapshots/MessagesCodeGenerator.Message.Trade.verified.txt
+++ b/tests/SbeCodeGenerator.Tests/Snapshots/MessagesCodeGenerator.Message.Trade.verified.txt
@@ -168,4 +168,18 @@ public ref struct TradeDataReader
 	/// Gets a readonly reference to the TradeData directly in the buffer (zero-copy).
 	/// </summary>
 	public ref readonly TradeData Data => ref Unsafe.As<byte, TradeData>(ref MemoryMarshal.GetReference(_buffer));
+	
+	/// <summary>
+	/// The full source buffer this reader was constructed from (block + groups + varData).
+	/// Note: the span may extend past the message; use <see cref="BytesConsumed"/> after <c>ReadGroups</c> to slice exactly.
+	/// </summary>
+	public readonly ReadOnlySpan<byte> Buffer => _buffer;
+	
+	/// <summary>
+	/// The fixed-size message block, sized to the wire's blockLength.
+	/// </summary>
+	public readonly ReadOnlySpan<byte> Block => _buffer.Slice(0, _blockLength);
+	
+	/// <summary>The wire blockLength this reader was constructed with.</summary>
+	public readonly int BlockLength => _blockLength;
 }


### PR DESCRIPTION
Closes #151.

## Problema
`{Msg}DataReader` guarda o buffer-fonte num campo privado mas não expõe. Consumidores que migram para `SbeDispatcher` (#147) e precisam **encaminhar/buffer os bytes brutos** (ex.: fluxo de snapshot-heal do B3 UMDF que enfileira a mensagem num slot do `ArrayPool` para replay posterior) ficam sem recurso — precisariam manter um switch manual paralelo só para capturar o body.

## Mudança
Adiciona 3 properties `readonly` em todo `{Msg}DataReader` gerado:

| Property | Tipo | Significado |
|---|---|---|
| `Buffer` | `ReadOnlySpan<byte>` | Span-fonte completo (pode passar do fim da mensagem; use `BytesConsumed` após `ReadGroups` para fatiar exato) |
| `Block` | `ReadOnlySpan<byte>` | Slice do block fixo, dimensionado pelo `blockLength` do wire |
| `BlockLength` | `int` | O `blockLength` que construiu o reader |

Todas `readonly` para evitar defensive copies quando o reader chega via `in`.

## Custo
Zero — os dados já existem no campo privado `_buffer`/`_blockLength`. São apenas accessors públicos. Sem mudança no tamanho do struct, sem branch novo, sem virtual.

## Estratégia alternativa considerada
Expor uma fábrica tipo `reader.AsBytes(int blockLengthOverride)`? Descartado: não há ganho sobre slicing direto e adiciona superfície de API. Manter spans crus dá ao consumidor 100% de controle.

## Testes
`tests/SbeCodeGenerator.IntegrationTests/ReaderBufferAccessTests.cs`:
- Fixed-layout (`Edge.Cases.Test.V0.TradeData`): valida `Block`/`Buffer`/`BlockLength` espelham o que o encoder escreveu.
- Variable-data (`Integration.Test.V0.OrderBookData`): valida que `Buffer.Slice(0, BytesConsumed)` após `ReadGroups` recupera o footprint completo da mensagem com groups.

187 + 128 testes verdes.